### PR TITLE
initialize default values for promoted properties

### DIFF
--- a/tests/Unit/Fixture/DefaultDto.php
+++ b/tests/Unit/Fixture/DefaultDto.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
+
+final class DefaultDto
+{
+    public bool $admin = true;
+
+    public function __construct(
+        public string $name,
+        public Email $email = new Email('info@patchlevel.de'),
+    ) {
+    }
+}

--- a/tests/Unit/Fixture/Email.php
+++ b/tests/Unit/Fixture/Email.php
@@ -8,7 +8,7 @@ final class Email
 {
     private string $value;
 
-    private function __construct(string $value)
+    public function __construct(string $value)
     {
         $this->value = $value;
     }

--- a/tests/Unit/MetadataHydratorTest.php
+++ b/tests/Unit/MetadataHydratorTest.php
@@ -8,6 +8,7 @@ use Patchlevel\Hydrator\DenormalizationFailure;
 use Patchlevel\Hydrator\Metadata\AttributeMetadataFactory;
 use Patchlevel\Hydrator\MetadataHydrator;
 use Patchlevel\Hydrator\NormalizationFailure;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\DefaultDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Email;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ParentDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileCreated;
@@ -64,6 +65,18 @@ final class MetadataHydratorTest extends TestCase
         );
 
         self::assertEquals($expected, $event);
+    }
+
+    public function testHydrateWithDefaults(): void
+    {
+        $object = $this->hydrator->hydrate(
+            DefaultDto::class,
+            ['name' => 'test']
+        );
+
+        self::assertEquals('test', $object->name);
+        self::assertEquals(new Email('info@patchlevel.de'), $object->email);
+        self::assertEquals(true, $object->admin);
     }
 
     public function testHydrateWithInheritance(): void


### PR DESCRIPTION
With property promotion there is the problem that default values are not written because the constructor is not executed during the hydration.

Here is an example:

```php
final class DefaultDto
{
    public bool $admin = true;

    public function __construct(
        public string $name,
        public Email $email = new Email('info@patchlevel.de'),
    ) {
    }
}
```

```json
{
    "name": "test"
}
```

Here's what happens:
* "test" is written into the property `name`
* property `admin` has "true" in it by default
* `email` was not initialized because the constructor was not executed

With this change, the default value is written in for every property that has no value and uses property promotion.