### PR TITLE
add union object normalizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,25 @@ final class AnotherDto
 > [!WARNING]
 > Circular references are not supported and will result in an exception.
 
+#### Union Object
+
+If you have a union type from multiple classes, then you can use the `UnionObjectNormalizer` normalizer
+
+```php
+use Patchlevel\Hydrator\Normalizer\UnionObjectNormalizer;
+
+#[UnionObjectNormalizer([
+  ContentBlock::class => 'content',
+  CodeBlock::class => 'code'
+])]
+interface Block
+{
+}
+```
+
+> [!NOTE]
+> Auto detection of the type is not possible. You have to specify the type yourself.
+
 #### Inline
 
 The `InlineNormalizer` allows you to define normalization and denormalization logic directly via closures.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -103,6 +103,12 @@ parameters:
 			path: src/Normalizer/ReflectionTypeUtil.php
 
 		-
+			message: '#^Parameter \#2 \$data of method Patchlevel\\Hydrator\\Hydrator\:\:hydrate\(\) expects array\<string, mixed\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Normalizer/UnionObjectNormalizer.php
+
+		-
 			message: '#^Method Patchlevel\\Hydrator\\Tests\\Unit\\Fixture\\DtoWithHooks\:\:postHydrate\(\) is unused\.$#'
 			identifier: method.unused
 			count: 1

--- a/src/Normalizer/UnionObjectNormalizer.php
+++ b/src/Normalizer/UnionObjectNormalizer.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Normalizer;
+
+use Attribute;
+use Patchlevel\Hydrator\Hydrator;
+
+use function array_flip;
+use function array_key_exists;
+use function array_keys;
+use function implode;
+use function is_array;
+use function is_object;
+use function is_string;
+use function sprintf;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
+final class UnionObjectNormalizer implements Normalizer, HydratorAwareNormalizer
+{
+    private Hydrator|null $hydrator = null;
+
+    /** @var array<string, class-string> */
+    private array $typeToClassMap;
+
+    /** @param array<class-string, string> $classToTypeMap */
+    public function __construct(
+        private readonly array $classToTypeMap,
+        private readonly string $typeFieldName = '_type',
+    ) {
+        $this->typeToClassMap = array_flip($classToTypeMap);
+    }
+
+    public function setHydrator(Hydrator $hydrator): void
+    {
+        $this->hydrator = $hydrator;
+    }
+
+    public function normalize(mixed $value): mixed
+    {
+        if (!$this->hydrator) {
+            throw new MissingHydrator();
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_object($value)) {
+            throw InvalidArgument::withWrongType(
+                sprintf('%s|null', implode('|', array_keys($this->classToTypeMap))),
+                $value,
+            );
+        }
+
+        if (!array_key_exists($value::class, $this->classToTypeMap)) {
+            throw InvalidArgument::withWrongType(
+                sprintf('%s|null', implode('|', array_keys($this->classToTypeMap))),
+                $value,
+            );
+        }
+
+        $data = $this->hydrator->extract($value);
+        $data[$this->typeFieldName] = $this->classToTypeMap[$value::class];
+
+        return $data;
+    }
+
+    public function denormalize(mixed $value): mixed
+    {
+        if (!$this->hydrator) {
+            throw new MissingHydrator();
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw InvalidArgument::withWrongType('array<string, mixed>|null', $value);
+        }
+
+        if (!array_key_exists($this->typeFieldName, $value)) {
+            throw new InvalidArgument(sprintf('missing type field "%s"', $this->typeFieldName));
+        }
+
+        $type = $value[$this->typeFieldName];
+
+        if (!is_string($type)) {
+            throw InvalidArgument::withWrongType('string', $type);
+        }
+
+        if (!array_key_exists($type, $this->typeToClassMap)) {
+            throw new InvalidArgument(sprintf('unknown type "%s"', $type));
+        }
+
+        $className = $this->typeToClassMap[$type];
+        unset($value[$this->typeFieldName]);
+
+        return $this->hydrator->hydrate($className, $value);
+    }
+
+    /**
+     * @return array{
+     *     typeToClassMap: array<string, class-string>,
+     *     classToTypeMap: array<class-string, string>,
+     *     typeFieldName: string,
+     *     hydrator: null
+     * }
+     */
+    public function __serialize(): array
+    {
+        return [
+            'typeToClassMap' => $this->typeToClassMap,
+            'classToTypeMap' => $this->classToTypeMap,
+            'typeFieldName' => $this->typeFieldName,
+            'hydrator' => null,
+        ];
+    }
+}

--- a/tests/Unit/Normalizer/UnionObjectNormalizerTest.php
+++ b/tests/Unit/Normalizer/UnionObjectNormalizerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Normalizer;
+
+use Patchlevel\Hydrator\Hydrator;
+use Patchlevel\Hydrator\Normalizer\InvalidArgument;
+use Patchlevel\Hydrator\Normalizer\MissingHydrator;
+use Patchlevel\Hydrator\Normalizer\UnionObjectNormalizer;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\Email;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function serialize;
+use function unserialize;
+
+#[CoversClass(UnionObjectNormalizer::class)]
+final class UnionObjectNormalizerTest extends TestCase
+{
+    public function testNormalizeMissingHydrator(): void
+    {
+        $this->expectException(MissingHydrator::class);
+
+        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $this->assertEquals(null, $normalizer->normalize(null));
+    }
+
+    public function testDenormalizeMissingHydrator(): void
+    {
+        $this->expectException(MissingHydrator::class);
+
+        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $this->assertEquals(null, $normalizer->denormalize(null));
+    }
+
+    public function testNormalizeWithNull(): void
+    {
+        $hydrator = $this->createStub(Hydrator::class);
+
+        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer->setHydrator($hydrator);
+
+        $this->assertEquals(null, $normalizer->normalize(null));
+    }
+
+    public function testDenormalizeWithNull(): void
+    {
+        $hydrator = $this->createStub(Hydrator::class);
+
+        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer->setHydrator($hydrator);
+
+        $this->assertEquals(null, $normalizer->denormalize(null));
+    }
+
+    public function testNormalizeWithInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage('type "Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileCreated|null" was expected but "string" was passed.');
+
+        $hydrator = $this->createStub(Hydrator::class);
+
+        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer->setHydrator($hydrator);
+        $normalizer->normalize('foo');
+    }
+
+    public function testDenormalizeWithInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage('array<string, mixed>|null" was expected but "string" was passed.');
+
+        $hydrator = $this->createStub(Hydrator::class);
+
+        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer->setHydrator($hydrator);
+        $normalizer->denormalize('foo');
+    }
+
+    public function testNormalizeWithValue(): void
+    {
+        $hydrator = $this->createMock(Hydrator::class);
+
+        $event = new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $hydrator
+            ->expects($this->once())
+            ->method('extract')
+            ->with($event)
+            ->willReturn(['profileId' => '1', 'email' => 'info@patchlevel.de']);
+
+        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer->setHydrator($hydrator);
+
+        self::assertEquals(
+            $normalizer->normalize($event),
+            ['profileId' => '1', 'email' => 'info@patchlevel.de', '_type' => 'created'],
+        );
+    }
+
+    public function testDenormalizeWithValue(): void
+    {
+        $hydrator = $this->createMock(Hydrator::class);
+
+        $expected = new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $hydrator
+            ->expects($this->once())
+            ->method('hydrate')
+            ->with(ProfileCreated::class, ['profileId' => '1', 'email' => 'info@patchlevel.de'])
+            ->willReturn($expected);
+
+        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer->setHydrator($hydrator);
+
+        $this->assertEquals(
+            $expected,
+            $normalizer->denormalize(['profileId' => '1', 'email' => 'info@patchlevel.de', '_type' => 'created']),
+        );
+    }
+
+    public function testSerialize(): void
+    {
+        $hydrator = $this->createStub(Hydrator::class);
+
+        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer->setHydrator($hydrator);
+
+        $serialized = serialize($normalizer);
+        $normalizer2 = unserialize($serialized);
+
+        self::assertInstanceOf(UnionObjectNormalizer::class, $normalizer2);
+        self::assertEquals(new UnionObjectNormalizer([ProfileCreated::class => 'created']), $normalizer2);
+    }
+}


### PR DESCRIPTION
```php
use Patchlevel\Hydrator\Normalizer\UnionObjectNormalizer;

#[UnionObjectNormalizer([
  ContentBlock::class => 'content',
  CodeBlock::class => 'code'
])]
interface Block
{
}
```