### PR TITLE
Infer Normalizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ vendor: composer.lock
 cs-check: vendor                                                                ## run phpcs
 	vendor/bin/phpcs
 
-.PHONY: phpcs-fix
+.PHONY: cs
 cs: vendor                                                                      ## run phpcs fixer
-	vendor/bin/phpcbf
+	vendor/bin/phpcbf || true
+	vendor/bin/phpcs
 
 .PHONY: phpstan
 phpstan: vendor                                                                 ## run phpstan static code analyser

--- a/README.md
+++ b/README.md
@@ -289,6 +289,56 @@ final class DTO
 }
 ```
 
+### Define normalizer on class level
+
+You can also set the attribute on the value object on class level. For that the normalizer needs to allow to be set on 
+class level.
+
+```php
+use Patchlevel\Hydrator\Normalizer\Normalizer;
+use Patchlevel\Hydrator\Normalizer\InvalidArgument;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
+class NameNormalizer implements Normalizer
+{
+    // ... same as before
+}
+```
+
+Then set the attribute on the value object.
+
+
+```php
+#[NameNormalizer]
+final class Name
+{
+    // ... same as before
+}
+```
+
+After that the DTO can then look like this.
+
+```php
+final class DTO
+{
+    public Name $name
+}
+```
+
+### Infer Normalizer
+
+We also integrated a process where the normalizer gets inferred by type. This means you don't need to define the 
+normalizer in for the properties or on class level. Right now this is only possible for Normalizer defined by our 
+library. There are exceptions though, the `ObjectNormalizer` and the `ArrayNormalizer`.
+
+These Normalizer can be inferred:
+
+* `DateTimeImmutableNormalizer` 
+* `DateTimeNormalizer` 
+* `DateTimeZoneNormalizer` 
+* `EnumNormalizer` 
+
+
 ### Normalized Name
 
 By default, the property name is used to name the field in the normalized result.

--- a/src/Metadata/AttributeMetadataFactory.php
+++ b/src/Metadata/AttributeMetadataFactory.php
@@ -188,10 +188,6 @@ final class AttributeMetadataFactory implements MetadataFactory
             return new EnumNormalizer($className);
         }
 
-        if (class_exists($className, false)) {
-            return new ObjectNormalizer($className);
-        }
-
         return null;
     }
 
@@ -303,7 +299,7 @@ final class AttributeMetadataFactory implements MetadataFactory
     }
 
     /** @return array<ReflectionAttribute<Normalizer>> */
-    public function getAttributeReflectionList(ReflectionProperty $reflectionProperty): array
+    private function getAttributeReflectionList(ReflectionProperty $reflectionProperty): array
     {
         $attributeReflectionList = $reflectionProperty->getAttributes(
             Normalizer::class,
@@ -320,7 +316,7 @@ final class AttributeMetadataFactory implements MetadataFactory
             return [];
         }
 
-        if (!class_exists($type->getName(), false)) {
+        if (!class_exists($type->getName())) {
             return [];
         }
 

--- a/src/Metadata/AttributeMetadataFactory.php
+++ b/src/Metadata/AttributeMetadataFactory.php
@@ -4,18 +4,30 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator\Metadata;
 
+use BackedEnum;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use Patchlevel\Hydrator\Attribute\DataSubjectId;
 use Patchlevel\Hydrator\Attribute\Ignore;
 use Patchlevel\Hydrator\Attribute\NormalizedName;
 use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Normalizer\DateTimeImmutableNormalizer;
+use Patchlevel\Hydrator\Normalizer\DateTimeNormalizer;
+use Patchlevel\Hydrator\Normalizer\DateTimeZoneNormalizer;
+use Patchlevel\Hydrator\Normalizer\EnumNormalizer;
 use Patchlevel\Hydrator\Normalizer\Normalizer;
+use Patchlevel\Hydrator\Normalizer\ObjectNormalizer;
 use Patchlevel\Hydrator\Normalizer\ReflectionTypeAwareNormalizer;
 use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionNamedType;
 use ReflectionProperty;
 
 use function array_key_exists;
 use function array_values;
+use function class_exists;
+use function is_a;
 
 final class AttributeMetadataFactory implements MetadataFactory
 {
@@ -132,29 +144,55 @@ final class AttributeMetadataFactory implements MetadataFactory
             return $reflectionProperty->getName();
         }
 
-        $attribute = $attributeReflectionList[0]->newInstance();
-
-        return $attribute->name();
+        return $attributeReflectionList[0]->newInstance()->name();
     }
 
     private function getNormalizer(ReflectionProperty $reflectionProperty): Normalizer|null
     {
-        $attributeReflectionList = $reflectionProperty->getAttributes(
-            Normalizer::class,
-            ReflectionAttribute::IS_INSTANCEOF,
-        );
+        $attributeReflectionList = $this->getAttributeReflectionList($reflectionProperty);
+        $reflectionPropertyType = $reflectionProperty->getType();
 
         if ($attributeReflectionList === []) {
+            if ($reflectionPropertyType instanceof ReflectionNamedType) {
+                return $this->inferNormalizer($reflectionPropertyType);
+            }
+
             return null;
         }
 
         $normalizer = $attributeReflectionList[0]->newInstance();
 
         if ($normalizer instanceof ReflectionTypeAwareNormalizer) {
-            $normalizer->handleReflectionType($reflectionProperty->getType());
+            $normalizer->handleReflectionType($reflectionPropertyType);
         }
 
         return $normalizer;
+    }
+
+    private function inferNormalizer(ReflectionNamedType $type): Normalizer|null
+    {
+        $className = $type->getName();
+
+        $normalizer = match ($className) {
+            DateTimeImmutable::class => new DateTimeImmutableNormalizer(),
+            DateTime::class => new DateTimeNormalizer(),
+            DateTimeZone::class => new DateTimeZoneNormalizer(),
+            default => null,
+        };
+
+        if ($normalizer) {
+            return $normalizer;
+        }
+
+        if (is_a($className, BackedEnum::class, true)) {
+            return new EnumNormalizer($className);
+        }
+
+        if (class_exists($className, false)) {
+            return new ObjectNormalizer($className);
+        }
+
+        return null;
     }
 
     private function hasIgnore(ReflectionProperty $reflectionProperty): bool
@@ -262,5 +300,33 @@ final class AttributeMetadataFactory implements MetadataFactory
         if ($hasPersonalData && $metadata->dataSubjectIdField() === null) {
             throw new MissingDataSubjectId($metadata->className());
         }
+    }
+
+    /** @return array<ReflectionAttribute<Normalizer>> */
+    public function getAttributeReflectionList(ReflectionProperty $reflectionProperty): array
+    {
+        $attributeReflectionList = $reflectionProperty->getAttributes(
+            Normalizer::class,
+            ReflectionAttribute::IS_INSTANCEOF,
+        );
+
+        if ($attributeReflectionList !== []) {
+            return $attributeReflectionList;
+        }
+
+        $type = $reflectionProperty->getType();
+
+        if (!$type instanceof ReflectionNamedType) {
+            return [];
+        }
+
+        if (!class_exists($type->getName(), false)) {
+            return [];
+        }
+
+        return (new ReflectionClass($type->getName()))->getAttributes(
+            Normalizer::class,
+            ReflectionAttribute::IS_INSTANCEOF,
+        );
     }
 }

--- a/src/Metadata/AttributeMetadataFactory.php
+++ b/src/Metadata/AttributeMetadataFactory.php
@@ -17,7 +17,6 @@ use Patchlevel\Hydrator\Normalizer\DateTimeNormalizer;
 use Patchlevel\Hydrator\Normalizer\DateTimeZoneNormalizer;
 use Patchlevel\Hydrator\Normalizer\EnumNormalizer;
 use Patchlevel\Hydrator\Normalizer\Normalizer;
-use Patchlevel\Hydrator\Normalizer\ObjectNormalizer;
 use Patchlevel\Hydrator\Normalizer\ReflectionTypeAwareNormalizer;
 use ReflectionAttribute;
 use ReflectionClass;

--- a/src/Normalizer/EnumNormalizer.php
+++ b/src/Normalizer/EnumNormalizer.php
@@ -12,7 +12,7 @@ use Throwable;
 use function is_int;
 use function is_string;
 
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
 final class EnumNormalizer implements Normalizer, ReflectionTypeAwareNormalizer
 {
     /** @param class-string<BackedEnum>|null $enum */

--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -10,7 +10,7 @@ use ReflectionType;
 
 use function is_array;
 
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
 final class ObjectNormalizer implements Normalizer, ReflectionTypeAwareNormalizer, HydratorAwareNormalizer
 {
     private Hydrator|null $hydrator = null;

--- a/tests/Unit/Fixture/InferNormalizerBrokenDto.php
+++ b/tests/Unit/Fixture/InferNormalizerBrokenDto.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
 
-use DateTime;
-use DateTimeImmutable;
-use DateTimeZone;
-
 final class InferNormalizerBrokenDto
 {
     /** @param array<string> $array */

--- a/tests/Unit/Fixture/InferNormalizerBrokenDto.php
+++ b/tests/Unit/Fixture/InferNormalizerBrokenDto.php
@@ -8,15 +8,11 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 
-final class InferNormalizerDto
+final class InferNormalizerBrokenDto
 {
     /** @param array<string> $array */
     public function __construct(
-        public Status $status,
-        public DateTimeImmutable $dateTimeImmutable,
-        public DateTime $dateTime,
-        public DateTimeZone $dateTimeZone,
-        public array $array,
+        public ProfileCreated $profileCreated,
     ) {
     }
 }

--- a/tests/Unit/Fixture/InferNormalizerDto.php
+++ b/tests/Unit/Fixture/InferNormalizerDto.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
+
+final class InferNormalizerDto
+{
+    public function __construct(
+        public Status $status,
+        public ProfileCreated $profileCreated,
+        public DateTimeImmutable $dateTimeImmutable,
+        public DateTime $dateTime,
+        public DateTimeZone $dateTimeZone,
+        public array $array,
+    ) {
+    }
+}

--- a/tests/Unit/Fixture/InferNormalizerDto.php
+++ b/tests/Unit/Fixture/InferNormalizerDto.php
@@ -10,6 +10,7 @@ use DateTimeZone;
 
 final class InferNormalizerDto
 {
+    /** @param array<string> $array */
     public function __construct(
         public Status $status,
         public ProfileCreated $profileCreated,

--- a/tests/Unit/Fixture/NormalizerInBaseClassDefinedDto.php
+++ b/tests/Unit/Fixture/NormalizerInBaseClassDefinedDto.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
+
+final class NormalizerInBaseClassDefinedDto
+{
+    public function __construct(
+        public StatusWithNormalizer $status,
+        public ProfileCreatedWithNormalizer $profileCreated,
+        public array $array,
+    ) {
+    }
+}

--- a/tests/Unit/Fixture/NormalizerInBaseClassDefinedDto.php
+++ b/tests/Unit/Fixture/NormalizerInBaseClassDefinedDto.php
@@ -6,6 +6,7 @@ namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
 
 final class NormalizerInBaseClassDefinedDto
 {
+    /** @param array<string> $array */
     public function __construct(
         public StatusWithNormalizer $status,
         public ProfileCreatedWithNormalizer $profileCreated,

--- a/tests/Unit/Fixture/ProfileCreatedWithNormalizer.php
+++ b/tests/Unit/Fixture/ProfileCreatedWithNormalizer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
+
+use Patchlevel\Hydrator\Normalizer\ObjectNormalizer;
+
+#[ObjectNormalizer]
+final class ProfileCreatedWithNormalizer
+{
+    public function __construct(
+        #[ProfileIdNormalizer]
+        public ProfileId $profileId,
+        #[EmailNormalizer]
+        public Email $email,
+    ) {
+    }
+}

--- a/tests/Unit/Fixture/StatusWithNormalizer.php
+++ b/tests/Unit/Fixture/StatusWithNormalizer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
+
+use Patchlevel\Hydrator\Normalizer\EnumNormalizer;
+
+#[EnumNormalizer]
+enum StatusWithNormalizer: string
+{
+    case Draft = 'draft';
+    case Pending = 'pending';
+    case Closed = 'closed';
+}

--- a/tests/Unit/MetadataHydratorTest.php
+++ b/tests/Unit/MetadataHydratorTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator\Tests\Unit;
 
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use Patchlevel\Hydrator\CircularReference;
 use Patchlevel\Hydrator\Cryptography\PayloadCryptographer;
 use Patchlevel\Hydrator\DenormalizationFailure;
@@ -15,10 +18,15 @@ use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle2Dto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle3Dto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\DefaultDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Email;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\InferNormalizerDto;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\NormalizerInBaseClassDefinedDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ParentDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileCreatedWithNormalizer;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileCreatedWrapper;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileId;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\Status;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\StatusWithNormalizer;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\WrongNormalizer;
 use Patchlevel\Hydrator\TypeMismatch;
 use PHPUnit\Framework\TestCase;
@@ -230,5 +238,57 @@ final class MetadataHydratorTest extends TestCase
         $return = $hydrator->extract($object);
 
         self::assertSame($encryptedPayload, $return);
+    }
+
+    public function testHydrateWithNormalizerInBaseClass(): void
+    {
+        $expected = new NormalizerInBaseClassDefinedDto(
+            StatusWithNormalizer::Draft,
+            new ProfileCreatedWithNormalizer(
+                ProfileId::fromString('1'),
+                Email::fromString('info@patchlevel.de'),
+            ),
+            ['foo'],
+        );
+
+        $event = $this->hydrator->hydrate(
+            NormalizerInBaseClassDefinedDto::class,
+            [
+                'status' => 'draft',
+                'profileCreated' => ['profileId' => '1', 'email' => 'info@patchlevel.de'],
+                'array' => ['foo'],
+            ],
+        );
+
+        self::assertEquals($expected, $event);
+    }
+
+    public function testHydrateWithInferNormalizer(): void
+    {
+        $expected = new InferNormalizerDto(
+            Status::Draft,
+            new ProfileCreated(
+                ProfileId::fromString('1'),
+                Email::fromString('info@patchlevel.de'),
+            ),
+            new DateTimeImmutable('2015-02-13 22:34:32+01:00'),
+            new DateTime('2015-02-13 22:34:32+01:00'),
+            new DateTimeZone('EDT'),
+            ['foo'],
+        );
+
+        $event = $this->hydrator->hydrate(
+            InferNormalizerDto::class,
+            [
+                'status' => 'draft',
+                'profileCreated' => ['profileId' => '1', 'email' => 'info@patchlevel.de'],
+                'dateTimeImmutable' => '2015-02-13T22:34:32+01:00',
+                'dateTime' => '2015-02-13T22:34:32+01:00',
+                'dateTimeZone' => 'EDT',
+                'array' => ['foo'],
+            ],
+        );
+
+        self::assertEquals($expected, $event);
     }
 }

--- a/tests/Unit/MetadataHydratorTest.php
+++ b/tests/Unit/MetadataHydratorTest.php
@@ -18,6 +18,7 @@ use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle2Dto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle3Dto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\DefaultDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Email;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\InferNormalizerBrokenDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\InferNormalizerDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\NormalizerInBaseClassDefinedDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ParentDto;
@@ -267,10 +268,6 @@ final class MetadataHydratorTest extends TestCase
     {
         $expected = new InferNormalizerDto(
             Status::Draft,
-            new ProfileCreated(
-                ProfileId::fromString('1'),
-                Email::fromString('info@patchlevel.de'),
-            ),
             new DateTimeImmutable('2015-02-13 22:34:32+01:00'),
             new DateTime('2015-02-13 22:34:32+01:00'),
             new DateTimeZone('EDT'),
@@ -281,7 +278,6 @@ final class MetadataHydratorTest extends TestCase
             InferNormalizerDto::class,
             [
                 'status' => 'draft',
-                'profileCreated' => ['profileId' => '1', 'email' => 'info@patchlevel.de'],
                 'dateTimeImmutable' => '2015-02-13T22:34:32+01:00',
                 'dateTime' => '2015-02-13T22:34:32+01:00',
                 'dateTimeZone' => 'EDT',
@@ -290,5 +286,16 @@ final class MetadataHydratorTest extends TestCase
         );
 
         self::assertEquals($expected, $event);
+    }
+
+    public function testHydrateWithInferNormalizerFailed(): void
+    {
+        $this->expectException(TypeMismatch::class);
+        $event = $this->hydrator->hydrate(
+            InferNormalizerBrokenDto::class,
+            [
+                'profileCreated' => ['profileId' => '1', 'email' => 'info@patchlevel.de'],
+            ],
+        );
     }
 }


### PR DESCRIPTION
The Enum and Object Normalizer can now be defined on class level. This removes repetition.

If no normalizer is defined we try to infer the normalizer which comes from this library.

The logic goes as follows:

1. Normalizer defined on property
2. Normalizer defined on class of property
3. Try to infer Normalizer