### PR TITLE
throw exception if normalizing is missing

### DIFF
--- a/src/MetadataHydrator.php
+++ b/src/MetadataHydrator.php
@@ -15,6 +15,7 @@ use TypeError;
 
 use function array_key_exists;
 use function array_values;
+use function is_object;
 use function spl_object_id;
 
 final class MetadataHydrator implements Hydrator
@@ -149,6 +150,10 @@ final class MetadataHydrator implements Hydrator
                             $e,
                         );
                     }
+                }
+
+                if (is_object($value)) {
+                    throw new NormalizationMissing($object::class, $propertyMetadata->propertyName());
                 }
 
                 /** @psalm-suppress MixedAssignment */

--- a/src/NormalizationMissing.php
+++ b/src/NormalizationMissing.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class NormalizationMissing extends RuntimeException implements HydratorException
+{
+    /** @param class-string $class */
+    public function __construct(string $class, string $property)
+    {
+        parent::__construct(
+            sprintf(
+                'normalization for the property "%s" in the class "%s" is missing. Please define a normalizer so the object can be normalized.',
+                $property,
+                $class,
+            ),
+        );
+    }
+}

--- a/tests/Unit/MetadataHydratorTest.php
+++ b/tests/Unit/MetadataHydratorTest.php
@@ -13,6 +13,7 @@ use Patchlevel\Hydrator\DenormalizationFailure;
 use Patchlevel\Hydrator\Metadata\AttributeMetadataFactory;
 use Patchlevel\Hydrator\MetadataHydrator;
 use Patchlevel\Hydrator\NormalizationFailure;
+use Patchlevel\Hydrator\NormalizationMissing;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle1Dto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle2Dto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle3Dto;
@@ -100,6 +101,19 @@ final class MetadataHydratorTest extends TestCase
         $dto3->to = $dto1;
 
         $this->hydrator->extract($dto1);
+    }
+
+    public function testExtractWithInferNormalizerFailed(): void
+    {
+        $this->expectException(NormalizationMissing::class);
+        $this->hydrator->extract(
+            new InferNormalizerBrokenDto(
+                new ProfileCreated(
+                    ProfileId::fromString('1'),
+                    Email::fromString('info@patchlevel.de'),
+                ),
+            ),
+        );
     }
 
     public function testHydrate(): void


### PR DESCRIPTION
This is a DX improvement, maybe a feature. We can't check all cases, especially if it's an array. But this helps if you forget something. Because it should never actually be an object at the end.