### PR TITLE
Rename `PersonalData` to `SensitiveData`

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ There are two events: `PostExtract` and `PreHydrate`.
 For this functionality we use the [symfony/event-dispatcher](https://symfony.com/doc/current/components/event_dispatcher.html).
 
 ```php
-use Patchlevel\Hydrator\Cryptography\PersonalDataPayloadCryptographer;
+use Patchlevel\Hydrator\Cryptography\SensitiveDataPayloadCryptographer;
 use Patchlevel\Hydrator\Cryptography\Store\CipherKeyStore;
 use Patchlevel\Hydrator\Metadata\Event\EventMetadataFactory;
 use Patchlevel\Hydrator\MetadataHydrator;
@@ -557,8 +557,8 @@ $hydrator = new MetadataHydrator(eventDispatcher: $eventDispatcher);
 
 ### Cryptography
 
-The library also offers the possibility to encrypt and decrypt personal data.
-For this purpose, a key is created for each subject ID, which is used to encrypt the personal data.
+The library also offers the possibility to encrypt and decrypt sensitive data, e.g. personal data of customers.
+For this purpose, a key is created for each subject ID, which is used to encrypt the sensitive data.
 
 #### DataSubjectId
 
@@ -579,27 +579,47 @@ final class EmailChanged
 
 > [!WARNING]
 > The `DataSubjectId` must be a string. You can use a normalizer to convert it to a string.
-> The Subject ID cannot be personal data.
+> The Subject ID cannot be sensitive data.
 
-#### PersonalData
-
-Next, we need to specify which fields we want to encrypt.
+First we need to define what the subject id is.
 
 ```php
 use Patchlevel\Hydrator\Attribute\DataSubjectId;
-use Patchlevel\Hydrator\Attribute\PersonalData;
 
-final class DTO 
+final class EmailChanged
 {
     public function __construct(
-        #[DataSubjectId]
+        #[DataSubjectId(name: 'profile')]
         public readonly string $profileId,
-        #[PersonalData]
-        public readonly string|null $email,
     ) {
     }
 }
 ```
+
+You can also use multiple data subject id's in one event by defining the name of the subject id's.
+
+```php
+use Patchlevel\Hydrator\Attribute\DataSubjectId;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
+
+final class DTO 
+{
+    public function __construct(
+        #[DataSubjectId(name: 'profile1')]
+        public readonly string $profile1Id,
+        #[SensitiveData(subjectIdName: 'profile1')]
+        public readonly string|null $email1,
+        #[DataSubjectId(name: 'profile2')]
+        public readonly string $profile2Id,
+        #[SensitiveData(subjectIdName: 'profile2')]
+        public readonly string|null $email2,
+    ) {
+    }
+}
+```
+
+> [!NOTE]
+> The default name of `DataSubjectId` is `default`.
 
 If the information could not be decrypted, then a fallback value is inserted.
 The default fallback value is `null`.
@@ -607,14 +627,14 @@ You can change this by setting the `fallback` parameter.
 In this case `unknown` is added:
 
 ```php
-use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 
 final class DTO
 {
     public function __construct(
         #[DataSubjectId]
         public readonly string $profileId,
-        #[PersonalData(fallback: 'unknown')]
+        #[SensitiveData(fallback: 'unknown')]
         public readonly string $name,
     ) {
     }
@@ -625,16 +645,16 @@ You can also use a callable as a fallback.
 
 ```php
 use Patchlevel\Hydrator\Attribute\DataSubjectId;
-use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 
 final class ProfileCreated
 {
     public function __construct(
         #[DataSubjectId]
         public readonly string $profileId,
-        #[PersonalData(fallback: 'deleted profile')]
+        #[SensitiveData(fallback: 'deleted profile')]
         public readonly string $name,
-        #[PersonalData(fallbackCallable: [self::class, 'anonymizedEmail'])]
+        #[SensitiveData(fallbackCallable: [self::class, 'anonymizedEmail'])]
         public readonly string $email,
     ) {
     }
@@ -655,13 +675,13 @@ final class ProfileCreated
 Here we show you how to configure the cryptography.
 
 ```php
-use Patchlevel\Hydrator\Cryptography\PersonalDataPayloadCryptographer;
+use Patchlevel\Hydrator\Cryptography\SensitiveDataPayloadCryptographer;
 use Patchlevel\Hydrator\Cryptography\Store\CipherKeyStore;
 use Patchlevel\Hydrator\Metadata\Event\EventMetadataFactory;
 use Patchlevel\Hydrator\MetadataHydrator;
 
 $cipherKeyStore = new InMemoryCipherKeyStore();
-$cryptographer = PersonalDataPayloadCryptographer::createWithDefaultSettings($cipherKeyStore);
+$cryptographer = SensitiveDataPayloadCryptographer::createWithDefaultSettings($cipherKeyStore);
 $hydrator = new MetadataHydrator(cryptographer: $cryptographer);
 ```
 

--- a/baseline.xml
+++ b/baseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.12.0@cf420941d061a57050b6c468ef2c778faf40aee2">
-  <file src="src/Attribute/PersonalData.php">
+  <file src="src/Attribute/SensitiveData.php">
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$fallbackCallable]]></code>
     </MixedPropertyTypeCoercion>
@@ -17,7 +17,7 @@
       <code><![CDATA[list<string>]]></code>
     </MoreSpecificReturnType>
   </file>
-  <file src="src/Cryptography/PersonalDataPayloadCryptographer.php">
+  <file src="src/Cryptography/SensitiveDataPayloadCryptographer.php">
     <MixedArgument>
       <code><![CDATA[$rawData]]></code>
     </MixedArgument>
@@ -41,7 +41,7 @@
   </file>
   <file src="src/Metadata/PropertyMetadata.php">
     <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$this->personalDataFallbackCallable]]></code>
+      <code><![CDATA[$this->sensitiveDataFallbackCallable]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/MetadataHydrator.php">

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,7 +16,7 @@ parameters:
 			message: '#^Parameter \#2 \$data of method Patchlevel\\Hydrator\\Cryptography\\Cipher\\Cipher\:\:decrypt\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Cryptography/PersonalDataPayloadCryptographer.php
+			path: src/Cryptography/SensitiveDataPayloadCryptographer.php
 
 		-
 			message: '#^Method Patchlevel\\Hydrator\\Guesser\\BuiltInGuesser\:\:guess\(\) has parameter \$type with generic class Symfony\\Component\\TypeInfo\\Type\\ObjectType but does not specify its types\: T$#'
@@ -51,12 +51,6 @@ parameters:
 		-
 			message: '#^Dead catch \- ReflectionException is never thrown in the try block\.$#'
 			identifier: catch.neverThrown
-			count: 1
-			path: src/Metadata/AttributeMetadataFactory.php
-
-		-
-			message: '#^Method Patchlevel\\Hydrator\\Metadata\\AttributeMetadataFactory\:\:getPersonalData\(\) should return array\{bool, mixed, \(callable\(string, mixed\)\: mixed\)\|null\} but returns array\{false, null\}\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Metadata/AttributeMetadataFactory.php
 

--- a/src/Attribute/DataSubjectId.php
+++ b/src/Attribute/DataSubjectId.php
@@ -10,7 +10,7 @@ use Attribute;
 final class DataSubjectId
 {
     public function __construct(
-        public readonly string $identifier = 'default',
+        public readonly string $name = 'default',
     ) {
     }
 }

--- a/src/Attribute/SensitiveData.php
+++ b/src/Attribute/SensitiveData.php
@@ -8,7 +8,7 @@ use Attribute;
 use InvalidArgumentException;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class PersonalData
+final class SensitiveData
 {
     /** @var (callable(string, mixed):mixed)|null */
     public readonly mixed $fallbackCallable;
@@ -16,7 +16,7 @@ final class PersonalData
     public function __construct(
         public readonly mixed $fallback = null,
         callable|null $fallbackCallable = null,
-        public readonly string $identifier = 'default',
+        public readonly string $subjectIdName = 'default',
     ) {
         $this->fallbackCallable = $fallbackCallable;
 

--- a/src/Cryptography/NotSensitiveData.php
+++ b/src/Cryptography/NotSensitiveData.php
@@ -8,11 +8,11 @@ use RuntimeException;
 
 use function sprintf;
 
-final class NotPersonalData extends RuntimeException
+final class NotSensitiveData extends RuntimeException
 {
     /** @param class-string $class */
     public function __construct(string $class, string $fieldName)
     {
-        parent::__construct(sprintf('Trying to get subject id for %s::%s which is not marked as personal data.', $class, $fieldName));
+        parent::__construct(sprintf('Trying to get subject id for %s::%s which is not marked as sensitive data.', $class, $fieldName));
     }
 }

--- a/src/Cryptography/SensitiveDataPayloadCryptographer.php
+++ b/src/Cryptography/SensitiveDataPayloadCryptographer.php
@@ -18,7 +18,7 @@ use function array_key_exists;
 use function is_int;
 use function is_string;
 
-final class PersonalDataPayloadCryptographer implements PayloadCryptographer
+final class SensitiveDataPayloadCryptographer implements PayloadCryptographer
 {
     public function __construct(
         private readonly CipherKeyStore $cipherKeyStore,
@@ -37,7 +37,7 @@ final class PersonalDataPayloadCryptographer implements PayloadCryptographer
     public function encrypt(ClassMetadata $metadata, array $data): array
     {
         foreach ($metadata->properties() as $propertyMetadata) {
-            if (!$propertyMetadata->isPersonalData()) {
+            if (!$propertyMetadata->isSensitiveData()) {
                 continue;
             }
 
@@ -77,7 +77,7 @@ final class PersonalDataPayloadCryptographer implements PayloadCryptographer
     public function decrypt(ClassMetadata $metadata, array $data): array
     {
         foreach ($metadata->properties() as $propertyMetadata) {
-            if (!$propertyMetadata->isPersonalData()) {
+            if (!$propertyMetadata->isSensitiveData()) {
                 continue;
             }
 
@@ -119,17 +119,17 @@ final class PersonalDataPayloadCryptographer implements PayloadCryptographer
     /** @param array<string, mixed> $data */
     private function subjectId(PropertyMetadata $propertyMetadata, ClassMetadata $metadata, array $data): string
     {
-        if (!$propertyMetadata->isPersonalData()) {
-            throw new NotPersonalData($metadata->className(), $propertyMetadata->propertyName());
+        if (!$propertyMetadata->isSensitiveData()) {
+            throw new NotSensitiveData($metadata->className(), $propertyMetadata->propertyName());
         }
 
-        $personalDataIdentifier = $propertyMetadata->personalDataIdentifier();
+        $sensitiveDataSubjectIdName = $propertyMetadata->sensitiveDataSubjectIdName();
 
-        if (!$metadata->hasSubjectIdIdentifier($personalDataIdentifier)) {
+        if (!$metadata->hasSubjectIdIdentifier($sensitiveDataSubjectIdName)) {
             throw new MissingSubjectId($metadata->className(), $propertyMetadata->propertyName());
         }
 
-        $fieldName = $metadata->getSubjectIdFieldName($personalDataIdentifier);
+        $fieldName = $metadata->getSubjectIdFieldName($sensitiveDataSubjectIdName);
 
         if (!array_key_exists($fieldName, $data)) {
             throw new MissingSubjectId($metadata->className(), $fieldName);
@@ -150,10 +150,10 @@ final class PersonalDataPayloadCryptographer implements PayloadCryptographer
 
     private function fallback(PropertyMetadata $propertyMetadata, string $subjectId, mixed $rawData): mixed
     {
-        $callback = $propertyMetadata->personalDataFallbackCallback();
+        $callback = $propertyMetadata->sensitiveDataFallbackCallable();
 
         if (!$callback) {
-            return $propertyMetadata->personalDataFallback();
+            return $propertyMetadata->sensitiveDataFallback();
         }
 
         return $callback($subjectId, $rawData);

--- a/src/Metadata/AttributeMetadataFactory.php
+++ b/src/Metadata/AttributeMetadataFactory.php
@@ -8,9 +8,9 @@ use Patchlevel\Hydrator\Attribute\DataSubjectId;
 use Patchlevel\Hydrator\Attribute\Ignore;
 use Patchlevel\Hydrator\Attribute\Lazy;
 use Patchlevel\Hydrator\Attribute\NormalizedName;
-use Patchlevel\Hydrator\Attribute\PersonalData;
 use Patchlevel\Hydrator\Attribute\PostHydrate;
 use Patchlevel\Hydrator\Attribute\PreExtract;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 use Patchlevel\Hydrator\Guesser\BuiltInGuesser;
 use Patchlevel\Hydrator\Guesser\Guesser;
 use Patchlevel\Hydrator\Normalizer\ArrayNormalizer;
@@ -156,7 +156,7 @@ final class AttributeMetadataFactory implements MetadataFactory
                 $fieldName,
                 $this->getNormalizer($reflectionProperty),
                 $this->getSubjectId($reflectionProperty),
-                ...$this->getPersonalData($reflectionProperty),
+                ...$this->getSensitiveData($reflectionProperty),
             );
         }
 
@@ -291,13 +291,13 @@ final class AttributeMetadataFactory implements MetadataFactory
             return null;
         }
 
-        return $attributeReflectionList[0]->newInstance()->identifier;
+        return $attributeReflectionList[0]->newInstance()->name;
     }
 
     /** @return array{string|null, mixed, (callable(string, mixed):mixed)|null} */
-    private function getPersonalData(ReflectionProperty $reflectionProperty): array
+    private function getSensitiveData(ReflectionProperty $reflectionProperty): array
     {
-        $attributeReflectionList = $reflectionProperty->getAttributes(PersonalData::class);
+        $attributeReflectionList = $reflectionProperty->getAttributes(SensitiveData::class);
 
         if ($attributeReflectionList === []) {
             return [null, null, null];
@@ -305,7 +305,7 @@ final class AttributeMetadataFactory implements MetadataFactory
 
         $attribute = $attributeReflectionList[0]->newInstance();
 
-        return [$attribute->identifier, $attribute->fallback, $attribute->fallbackCallable];
+        return [$attribute->subjectIdName, $attribute->fallback, $attribute->fallbackCallable];
     }
 
     private function validate(ClassMetadata $metadata): void
@@ -313,11 +313,11 @@ final class AttributeMetadataFactory implements MetadataFactory
         $subjectIds = [];
 
         foreach ($metadata->properties() as $property) {
-            if ($property->isPersonalData() && $property->isSubjectId()) {
-                throw new SubjectIdAndPersonalDataConflict($metadata->className(), $property->propertyName());
+            if ($property->isSensitiveData() && $property->isSubjectId()) {
+                throw new SubjectIdAndSensitiveDataConflict($metadata->className(), $property->propertyName());
             }
 
-            if ($property->isPersonalData() && !$metadata->hasSubjectIdIdentifier($property->personalDataIdentifier())) {
+            if ($property->isSensitiveData() && !$metadata->hasSubjectIdIdentifier($property->sensitiveDataSubjectIdName())) {
                 throw new MissingDataSubjectId($metadata->className());
             }
 
@@ -325,7 +325,7 @@ final class AttributeMetadataFactory implements MetadataFactory
                 continue;
             }
 
-            $subjectIdIdentifier = $property->subjectIdIdentifier();
+            $subjectIdIdentifier = $property->subjectIdName();
 
             if (array_key_exists($subjectIdIdentifier, $subjectIds)) {
                 throw new DuplicateSubjectIdIdentifier(

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -83,7 +83,7 @@ final class ClassMetadata
     public function hasSubjectIdIdentifier(string $subjectIdIdentifier): bool
     {
         foreach ($this->properties as $property) {
-            if ($property->subjectIdIdentifier() === $subjectIdIdentifier) {
+            if ($property->subjectIdName() === $subjectIdIdentifier) {
                 return true;
             }
         }
@@ -94,7 +94,7 @@ final class ClassMetadata
     public function getSubjectIdFieldName(string $subjectIdIdentifier): string
     {
         foreach ($this->properties as $property) {
-            if ($property->subjectIdIdentifier() === $subjectIdIdentifier) {
+            if ($property->subjectIdName() === $subjectIdIdentifier) {
                 return $property->fieldName();
             }
         }

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -17,24 +17,24 @@ use function str_starts_with;
  *     property: string,
  *     fieldName: string,
  *     normalizer: Normalizer|null,
- *     subjectIdIdentifier: string|null,
- *     personalDataIdentifier: string|null,
- *     personalDataFallback: mixed
+ *     subjectIdName: string|null,
+ *     sensitiveDataSubjectIdName: string|null,
+ *     sensitiveDataFallback: mixed
  * }
  */
 final class PropertyMetadata
 {
     private const ENCRYPTED_PREFIX = '!';
 
-    /** @param (callable(string, mixed):mixed)|null $personalDataFallbackCallable */
+    /** @param (callable(string, mixed):mixed)|null $sensitiveDataFallbackCallable */
     public function __construct(
         private readonly ReflectionProperty $reflection,
         private readonly string $fieldName,
         private readonly Normalizer|null $normalizer = null,
-        private readonly string|null $subjectIdIdentifier = null,
-        private readonly string|null $personalDataIdentifier = null,
-        private readonly mixed $personalDataFallback = null,
-        private readonly mixed $personalDataFallbackCallable = null,
+        private readonly string|null $subjectIdName = null,
+        private readonly string|null $sensitiveDataSubjectIdName = null,
+        private readonly mixed $sensitiveDataFallback = null,
+        private readonly mixed $sensitiveDataFallbackCallable = null,
     ) {
         if (str_starts_with($fieldName, self::ENCRYPTED_PREFIX)) {
             throw new InvalidArgumentException('fieldName must not start with !');
@@ -76,41 +76,41 @@ final class PropertyMetadata
         return $this->reflection->getValue($object);
     }
 
-    /** @phpstan-assert-if-true !null $this->personalDataIdentifier() */
-    public function isPersonalData(): bool
+    /** @phpstan-assert-if-true !null $this->sensitiveDataSubjectIdName() */
+    public function isSensitiveData(): bool
     {
-        return $this->personalDataIdentifier !== null;
+        return $this->sensitiveDataSubjectIdName !== null;
     }
 
-    /** @phpstan-assert-if-true !null $this->subjectIdIdentifier() */
+    /** @phpstan-assert-if-true !null $this->subjectIdName() */
     public function isSubjectId(): bool
     {
-        return $this->subjectIdIdentifier !== null;
+        return $this->subjectIdName !== null;
     }
 
-    public function subjectIdIdentifier(): string|null
+    public function subjectIdName(): string|null
     {
-        return $this->subjectIdIdentifier;
+        return $this->subjectIdName;
     }
 
-    public function personalDataFallback(): mixed
+    public function sensitiveDataFallback(): mixed
     {
-        return $this->personalDataFallback;
+        return $this->sensitiveDataFallback;
     }
 
     /** @return (Closure(string, mixed):mixed)|null */
-    public function personalDataFallbackCallback(): Closure|null
+    public function sensitiveDataFallbackCallable(): Closure|null
     {
-        if ($this->personalDataFallbackCallable) {
-            return ($this->personalDataFallbackCallable)(...);
+        if ($this->sensitiveDataFallbackCallable) {
+            return ($this->sensitiveDataFallbackCallable)(...);
         }
 
         return null;
     }
 
-    public function personalDataIdentifier(): string|null
+    public function sensitiveDataSubjectIdName(): string|null
     {
-        return $this->personalDataIdentifier;
+        return $this->sensitiveDataSubjectIdName;
     }
 
     /** @return serialized */
@@ -121,9 +121,9 @@ final class PropertyMetadata
             'property' => $this->reflection->getName(),
             'fieldName' => $this->fieldName,
             'normalizer' => $this->normalizer,
-            'subjectIdIdentifier' => $this->subjectIdIdentifier,
-            'personalDataIdentifier' => $this->personalDataIdentifier,
-            'personalDataFallback' => $this->personalDataFallback,
+            'subjectIdName' => $this->subjectIdName,
+            'sensitiveDataSubjectIdName' => $this->sensitiveDataSubjectIdName,
+            'sensitiveDataFallback' => $this->sensitiveDataFallback,
         ];
     }
 
@@ -133,8 +133,8 @@ final class PropertyMetadata
         $this->reflection = new ReflectionProperty($data['className'], $data['property']);
         $this->fieldName = $data['fieldName'];
         $this->normalizer = $data['normalizer'];
-        $this->subjectIdIdentifier = $data['subjectIdIdentifier'];
-        $this->personalDataIdentifier = $data['personalDataIdentifier'];
-        $this->personalDataFallback = $data['personalDataFallback'];
+        $this->subjectIdName = $data['subjectIdName'];
+        $this->sensitiveDataSubjectIdName = $data['sensitiveDataSubjectIdName'];
+        $this->sensitiveDataFallback = $data['sensitiveDataFallback'];
     }
 }

--- a/src/Metadata/SubjectIdAndSensitiveDataConflict.php
+++ b/src/Metadata/SubjectIdAndSensitiveDataConflict.php
@@ -8,14 +8,14 @@ use RuntimeException;
 
 use function sprintf;
 
-final class SubjectIdAndPersonalDataConflict extends RuntimeException implements MetadataException
+final class SubjectIdAndSensitiveDataConflict extends RuntimeException implements MetadataException
 {
     /** @param class-string $class */
     public function __construct(string $class, string $property)
     {
         parent::__construct(
             sprintf(
-                'Personal data cannot be used as a subject id. Fix subject id for %s::%s.',
+                'Sensitive data cannot be used as a subject id. Fix subject id for %s::%s.',
                 $class,
                 $property,
             ),

--- a/tests/Benchmark/Fixture/ProfileCreated.php
+++ b/tests/Benchmark/Fixture/ProfileCreated.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\Hydrator\Tests\Benchmark\Fixture;
 
 use Patchlevel\Hydrator\Attribute\DataSubjectId;
-use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 
 final class ProfileCreated
 {
@@ -14,7 +14,7 @@ final class ProfileCreated
         #[ProfileIdNormalizer]
         #[DataSubjectId]
         public ProfileId $profileId,
-        #[PersonalData(fallback: 'unknown')]
+        #[SensitiveData(fallback: 'unknown')]
         public string $name,
         public array $skills = [],
     ) {

--- a/tests/Benchmark/HydratorWithCryptographyBench.php
+++ b/tests/Benchmark/HydratorWithCryptographyBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\Hydrator\Tests\Benchmark;
 
 use Patchlevel\Hydrator\Cryptography\CryptographySubscriber;
-use Patchlevel\Hydrator\Cryptography\PersonalDataPayloadCryptographer;
+use Patchlevel\Hydrator\Cryptography\SensitiveDataPayloadCryptographer;
 use Patchlevel\Hydrator\Cryptography\Store\InMemoryCipherKeyStore;
 use Patchlevel\Hydrator\Hydrator;
 use Patchlevel\Hydrator\MetadataHydrator;
@@ -28,7 +28,7 @@ final class HydratorWithCryptographyBench
 
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->addSubscriber(new CryptographySubscriber(
-            PersonalDataPayloadCryptographer::createWithDefaultSettings($this->store),
+            SensitiveDataPayloadCryptographer::createWithDefaultSettings($this->store),
         ));
 
         $this->hydrator = MetadataHydrator::create(eventDispatcher: $eventDispatcher);

--- a/tests/Unit/Cryptography/SensitiveDataPayloadCryptographerTest.php
+++ b/tests/Unit/Cryptography/SensitiveDataPayloadCryptographerTest.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator\Tests\Unit\Cryptography;
 
-use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 use Patchlevel\Hydrator\Cryptography\Cipher\Cipher;
 use Patchlevel\Hydrator\Cryptography\Cipher\CipherKey;
 use Patchlevel\Hydrator\Cryptography\Cipher\CipherKeyFactory;
 use Patchlevel\Hydrator\Cryptography\Cipher\DecryptionFailed;
 use Patchlevel\Hydrator\Cryptography\MissingSubjectId;
-use Patchlevel\Hydrator\Cryptography\PersonalDataPayloadCryptographer;
+use Patchlevel\Hydrator\Cryptography\SensitiveDataPayloadCryptographer;
 use Patchlevel\Hydrator\Cryptography\Store\CipherKeyNotExists;
 use Patchlevel\Hydrator\Cryptography\Store\CipherKeyStore;
 use Patchlevel\Hydrator\Cryptography\UnsupportedSubjectId;
 use Patchlevel\Hydrator\Metadata\AttributeMetadataFactory;
 use Patchlevel\Hydrator\Metadata\ClassMetadata;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Email;
-use Patchlevel\Hydrator\Tests\Unit\Fixture\PersonalDataProfileCreated;
-use Patchlevel\Hydrator\Tests\Unit\Fixture\PersonalDataProfileCreatedFallbackCallback;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\SensitiveDataProfileCreated;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\SensitiveDataProfileCreatedFallbackCallback;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Patchlevel\Hydrator\Cryptography\PersonalDataPayloadCryptographer */
-final class PersonalDataPayloadCryptographerTest extends TestCase
+/** @covers \Patchlevel\Hydrator\Cryptography\SensitiveDataPayloadCryptographer */
+final class SensitiveDataPayloadCryptographerTest extends TestCase
 {
     public function testSkipEncrypt(): void
     {
@@ -32,7 +32,7 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipherKeyFactory = $this->createMock(CipherKeyFactory::class);
         $cipher = $this->createMock(Cipher::class);
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
@@ -40,7 +40,7 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
 
         $payload = ['id' => 'foo', 'email' => 'info@patchlevel.de'];
 
-        $result = $cryptographer->encrypt($this->metadata(PersonalData::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
+        $result = $cryptographer->encrypt($this->metadata(SensitiveData::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
 
         self::assertSame($payload, $result);
     }
@@ -64,13 +64,13 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipher->expects($this->once())->method('encrypt')->with($cipherKey, 'info@patchlevel.de')
             ->willReturn('encrypted');
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
         );
 
-        $result = $cryptographer->encrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
+        $result = $cryptographer->encrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
 
         self::assertEquals(['id' => 'foo', 'email' => 'encrypted'], $result);
     }
@@ -97,13 +97,13 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipher->expects($this->once())->method('encrypt')->with($cipherKey, 'info@patchlevel.de')
             ->willReturn('encrypted');
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
         );
 
-        $result = $cryptographer->encrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
+        $result = $cryptographer->encrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
 
         self::assertEquals(['id' => 'foo', 'email' => 'encrypted'], $result);
     }
@@ -130,14 +130,14 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipher->expects($this->once())->method('encrypt')->with($cipherKey, 'info@patchlevel.de')
             ->willReturn('encrypted');
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
             true,
         );
 
-        $result = $cryptographer->encrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
+        $result = $cryptographer->encrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
 
         self::assertEquals(['id' => 'foo', '!email' => 'encrypted'], $result);
     }
@@ -150,7 +150,7 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipherKeyFactory = $this->createMock(CipherKeyFactory::class);
         $cipher = $this->createMock(Cipher::class);
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
@@ -158,7 +158,7 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
 
         $payload = ['id' => 'foo', 'email' => 'info@patchlevel.de'];
 
-        $result = $cryptographer->decrypt($this->metadata(PersonalData::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
+        $result = $cryptographer->decrypt($this->metadata(SensitiveData::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
 
         self::assertSame($payload, $result);
     }
@@ -174,13 +174,13 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipher = $this->createMock(Cipher::class);
         $cipher->expects($this->never())->method('decrypt');
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
         );
 
-        $result = $cryptographer->decrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => 'foo', 'email' => 'encrypted']);
+        $result = $cryptographer->decrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => 'foo', 'email' => 'encrypted']);
 
         self::assertEquals(['id' => 'foo', 'email' => new Email('unknown')], $result);
     }
@@ -207,13 +207,13 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipher->expects($this->once())->method('decrypt')->with($cipherKey, 'encrypted')
             ->willThrowException(new DecryptionFailed());
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
         );
 
-        $result = $cryptographer->decrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => 'foo', 'email' => 'encrypted']);
+        $result = $cryptographer->decrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => 'foo', 'email' => 'encrypted']);
 
         self::assertEquals(['id' => 'foo', 'email' => new Email('unknown')], $result);
     }
@@ -237,13 +237,13 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipher->expects($this->once())->method('decrypt')->with($cipherKey, 'encrypted')
             ->willThrowException(new DecryptionFailed());
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
         );
 
-        $result = $cryptographer->decrypt($this->metadata(PersonalDataProfileCreatedFallbackCallback::class), ['id' => 'foo', 'email' => 'encrypted']);
+        $result = $cryptographer->decrypt($this->metadata(SensitiveDataProfileCreatedFallbackCallback::class), ['id' => 'foo', 'email' => 'encrypted']);
 
         self::assertEquals(['id' => 'foo', 'email' => new Email('foo@example.com')], $result);
     }
@@ -267,14 +267,14 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipher->expects($this->once())->method('decrypt')->with($cipherKey, 'encrypted')
             ->willReturn('info@patchlevel.de');
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
             false,
         );
 
-        $result = $cryptographer->decrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => 'foo', 'email' => 'encrypted']);
+        $result = $cryptographer->decrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => 'foo', 'email' => 'encrypted']);
 
         self::assertEquals(['id' => 'foo', 'email' => 'info@patchlevel.de'], $result);
     }
@@ -301,14 +301,14 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
             ->with($cipherKey, 'encrypted')
             ->willReturn('info@patchlevel.de');
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
             true,
         );
 
-        $result = $cryptographer->decrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => 'foo', '!email' => 'encrypted']);
+        $result = $cryptographer->decrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => 'foo', '!email' => 'encrypted']);
 
         self::assertEquals(['id' => 'foo', 'email' => 'info@patchlevel.de'], $result);
     }
@@ -330,14 +330,14 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
 
         $cipher = $this->createMock(Cipher::class);
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
             true,
         );
 
-        $result = $cryptographer->decrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
+        $result = $cryptographer->decrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => 'foo', 'email' => 'info@patchlevel.de']);
 
         self::assertEquals(['id' => 'foo', 'email' => 'info@patchlevel.de'], $result);
     }
@@ -361,7 +361,7 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipher->expects($this->once())->method('decrypt')->with($cipherKey, 'encrypted')
             ->willReturn('info@patchlevel.de');
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
@@ -369,7 +369,7 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
             true,
         );
 
-        $result = $cryptographer->decrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => 'foo', 'email' => 'encrypted']);
+        $result = $cryptographer->decrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => 'foo', 'email' => 'encrypted']);
 
         self::assertEquals(['id' => 'foo', 'email' => 'info@patchlevel.de'], $result);
     }
@@ -382,13 +382,13 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipherKeyFactory = $this->createMock(CipherKeyFactory::class);
         $cipher = $this->createMock(Cipher::class);
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
         );
 
-        $cryptographer->decrypt($this->metadata(PersonalDataProfileCreated::class), ['id' => null, 'email' => 'encrypted']);
+        $cryptographer->decrypt($this->metadata(SensitiveDataProfileCreated::class), ['id' => null, 'email' => 'encrypted']);
     }
 
     public function testMissingSubjectId(): void
@@ -399,24 +399,24 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         $cipherKeyFactory = $this->createMock(CipherKeyFactory::class);
         $cipher = $this->createMock(Cipher::class);
 
-        $cryptographer = new PersonalDataPayloadCryptographer(
+        $cryptographer = new SensitiveDataPayloadCryptographer(
             $cipherKeyStore,
             $cipherKeyFactory,
             $cipher,
         );
 
-        $cryptographer->decrypt($this->metadata(PersonalDataProfileCreated::class), ['email' => 'encrypted']);
+        $cryptographer->decrypt($this->metadata(SensitiveDataProfileCreated::class), ['email' => 'encrypted']);
     }
 
     public function testCreateWithOpenssl(): void
     {
         $cipherKeyStore = $this->createMock(CipherKeyStore::class);
 
-        $cryptographer = PersonalDataPayloadCryptographer::createWithOpenssl(
+        $cryptographer = SensitiveDataPayloadCryptographer::createWithOpenssl(
             $cipherKeyStore,
         );
 
-        self::assertInstanceOf(PersonalDataPayloadCryptographer::class, $cryptographer);
+        self::assertInstanceOf(SensitiveDataPayloadCryptographer::class, $cryptographer);
     }
 
     /** @param class-string $class */

--- a/tests/Unit/Fixture/ChildWithSensitiveDataDto.php
+++ b/tests/Unit/Fixture/ChildWithSensitiveDataDto.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
 
-use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 
-abstract class ChildWithPersonalDataDto
+abstract class ChildWithSensitiveDataDto
 {
     public function __construct(
         #[EmailNormalizer]
-        #[PersonalData]
+        #[SensitiveData]
         private Email $email,
     ) {
     }

--- a/tests/Unit/Fixture/ChildWithSensitiveDataWithIdentifierDto.php
+++ b/tests/Unit/Fixture/ChildWithSensitiveDataWithIdentifierDto.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
 
-use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 
-abstract class ChildWithPersonalDataWithIdentifierDto
+abstract class ChildWithSensitiveDataWithIdentifierDto
 {
     public function __construct(
         #[EmailNormalizer]
-        #[PersonalData(identifier: 'profile')]
+        #[SensitiveData(subjectIdName: 'profile')]
         private Email $email,
     ) {
     }

--- a/tests/Unit/Fixture/MissingSubjectIdDto.php
+++ b/tests/Unit/Fixture/MissingSubjectIdDto.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
 
-use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 
 final class MissingSubjectIdDto
 {
     public function __construct(
-        #[PersonalData(fallback: 'fallback')]
+        #[SensitiveData(fallback: 'fallback')]
         public Email $email,
     ) {
     }

--- a/tests/Unit/Fixture/ParentWithSensitiveDataDto.php
+++ b/tests/Unit/Fixture/ParentWithSensitiveDataDto.php
@@ -6,7 +6,7 @@ namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
 
 use Patchlevel\Hydrator\Attribute\DataSubjectId;
 
-final class ParentWithPersonalDataDto extends ChildWithPersonalDataDto
+final class ParentWithSensitiveDataDto extends ChildWithSensitiveDataDto
 {
     public function __construct(
         #[IdNormalizer]

--- a/tests/Unit/Fixture/ParentWithSensitiveDataWithIdentifierDto.php
+++ b/tests/Unit/Fixture/ParentWithSensitiveDataWithIdentifierDto.php
@@ -6,11 +6,11 @@ namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
 
 use Patchlevel\Hydrator\Attribute\DataSubjectId;
 
-final class ParentWithPersonalDataWithIdentifierDto extends ChildWithPersonalDataWithIdentifierDto
+final class ParentWithSensitiveDataWithIdentifierDto extends ChildWithSensitiveDataWithIdentifierDto
 {
     public function __construct(
         #[IdNormalizer]
-        #[DataSubjectId(identifier: 'profile')]
+        #[DataSubjectId(name: 'profile')]
         public ProfileId $profileId,
         Email $email,
     ) {

--- a/tests/Unit/Fixture/SensitiveDataProfileCreated.php
+++ b/tests/Unit/Fixture/SensitiveDataProfileCreated.php
@@ -6,9 +6,9 @@ namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
 
 use Patchlevel\Hydrator\Attribute\DataSubjectId;
 use Patchlevel\Hydrator\Attribute\NormalizedName;
-use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 
-final class PersonalDataProfileCreated
+final class SensitiveDataProfileCreated
 {
     public function __construct(
         #[IdNormalizer]
@@ -16,7 +16,7 @@ final class PersonalDataProfileCreated
         #[DataSubjectId]
         public ProfileId $profileId,
         #[EmailNormalizer]
-        #[PersonalData(fallback: new Email('unknown'))]
+        #[SensitiveData(fallback: new Email('unknown'))]
         public Email $email,
     ) {
     }

--- a/tests/Unit/Fixture/SensitiveDataProfileCreatedFallbackCallback.php
+++ b/tests/Unit/Fixture/SensitiveDataProfileCreatedFallbackCallback.php
@@ -6,9 +6,9 @@ namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
 
 use Patchlevel\Hydrator\Attribute\DataSubjectId;
 use Patchlevel\Hydrator\Attribute\NormalizedName;
-use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 
-final class PersonalDataProfileCreatedFallbackCallback
+final class SensitiveDataProfileCreatedFallbackCallback
 {
     public function __construct(
         #[IdNormalizer]
@@ -16,7 +16,7 @@ final class PersonalDataProfileCreatedFallbackCallback
         #[DataSubjectId]
         public ProfileId $profileId,
         #[EmailNormalizer]
-        #[PersonalData(fallbackCallable: [self::class, 'emailFallback'])]
+        #[SensitiveData(fallbackCallable: [self::class, 'emailFallback'])]
         public Email $email,
     ) {
     }

--- a/tests/Unit/Metadata/AttributeMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/AttributeMetadataFactoryTest.php
@@ -7,16 +7,16 @@ namespace Patchlevel\Hydrator\Tests\Unit\Metadata;
 use Patchlevel\Hydrator\Attribute\DataSubjectId;
 use Patchlevel\Hydrator\Attribute\Lazy;
 use Patchlevel\Hydrator\Attribute\NormalizedName;
-use Patchlevel\Hydrator\Attribute\PersonalData;
 use Patchlevel\Hydrator\Attribute\PostHydrate;
 use Patchlevel\Hydrator\Attribute\PreExtract;
+use Patchlevel\Hydrator\Attribute\SensitiveData;
 use Patchlevel\Hydrator\Metadata\AttributeMetadataFactory;
 use Patchlevel\Hydrator\Metadata\ClassNotFound;
 use Patchlevel\Hydrator\Metadata\DuplicatedFieldNameInMetadata;
 use Patchlevel\Hydrator\Metadata\DuplicateSubjectIdIdentifier;
 use Patchlevel\Hydrator\Metadata\MissingDataSubjectId;
 use Patchlevel\Hydrator\Metadata\PropertyMetadataNotFound;
-use Patchlevel\Hydrator\Metadata\SubjectIdAndPersonalDataConflict;
+use Patchlevel\Hydrator\Metadata\SubjectIdAndSensitiveDataConflict;
 use Patchlevel\Hydrator\Normalizer\EnumNormalizer;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\BrokenParentDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\DistributionCreated;
@@ -28,8 +28,8 @@ use Patchlevel\Hydrator\Tests\Unit\Fixture\IgnoreDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\IgnoreParentDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\MissingSubjectIdDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ParentDto;
-use Patchlevel\Hydrator\Tests\Unit\Fixture\ParentWithPersonalDataDto;
-use Patchlevel\Hydrator\Tests\Unit\Fixture\ParentWithPersonalDataWithIdentifierDto;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\ParentWithSensitiveDataDto;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\ParentWithSensitiveDataWithIdentifierDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileId;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Status;
 use PHPUnit\Framework\TestCase;
@@ -326,14 +326,14 @@ final class AttributeMetadataFactoryTest extends TestCase
         $metadata->propertyForField('email');
     }
 
-    public function testPersonalData(): void
+    public function testSensitiveData(): void
     {
         $event = new class ('id', 'name') {
             public function __construct(
                 #[DataSubjectId]
                 #[NormalizedName('_id')]
                 public string $id,
-                #[PersonalData('fallback')]
+                #[SensitiveData('fallback')]
                 #[NormalizedName('_name')]
                 public string $name,
             ) {
@@ -345,16 +345,16 @@ final class AttributeMetadataFactoryTest extends TestCase
 
         self::assertCount(2, $metadata->properties());
 
-        self::assertSame(false, $metadata->propertyForField('_id')->isPersonalData());
+        self::assertSame(false, $metadata->propertyForField('_id')->isSensitiveData());
         self::assertSame(true, $metadata->propertyForField('_id')->isSubjectId());
-        self::assertSame('default', $metadata->propertyForField('_id')->subjectIdIdentifier());
-        self::assertSame(null, $metadata->propertyForField('_id')->personalDataFallback());
-        self::assertSame(null, $metadata->propertyForField('_id')->personalDataIdentifier());
+        self::assertSame('default', $metadata->propertyForField('_id')->subjectIdName());
+        self::assertSame(null, $metadata->propertyForField('_id')->sensitiveDataFallback());
+        self::assertSame(null, $metadata->propertyForField('_id')->sensitiveDataSubjectIdName());
 
-        self::assertSame(true, $metadata->propertyForField('_name')->isPersonalData());
+        self::assertSame(true, $metadata->propertyForField('_name')->isSensitiveData());
         self::assertSame(false, $metadata->propertyForField('_name')->isSubjectId());
-        self::assertSame('fallback', $metadata->propertyForField('_name')->personalDataFallback());
-        self::assertSame('default', $metadata->propertyForField('_name')->personalDataIdentifier());
+        self::assertSame('fallback', $metadata->propertyForField('_name')->sensitiveDataFallback());
+        self::assertSame('default', $metadata->propertyForField('_name')->sensitiveDataSubjectIdName());
     }
 
     public function testMissingDataSubjectId(): void
@@ -365,18 +365,18 @@ final class AttributeMetadataFactoryTest extends TestCase
         $metadataFactory->metadata(MissingSubjectIdDto::class);
     }
 
-    public function testSubjectIdAndPersonalDataConflict(): void
+    public function testSubjectIdAndSensitiveDataConflict(): void
     {
         $event = new class ('name') {
             public function __construct(
                 #[DataSubjectId]
-                #[PersonalData]
+                #[SensitiveData]
                 public string $name,
             ) {
             }
         };
 
-        $this->expectException(SubjectIdAndPersonalDataConflict::class);
+        $this->expectException(SubjectIdAndSensitiveDataConflict::class);
 
         $metadataFactory = new AttributeMetadataFactory();
         $metadataFactory->metadata($event::class);
@@ -400,20 +400,20 @@ final class AttributeMetadataFactoryTest extends TestCase
         $metadataFactory->metadata($event::class);
     }
 
-    public function testPersonalDataWithMultipleDataSubjectIdWithDifferentIdentifiers(): void
+    public function testSensitiveDataWithMultipleDataSubjectIdWithDifferentNames(): void
     {
         $event = new class ('fooId', 'fooName', 'barId', 'barName') {
             public function __construct(
-                #[DataSubjectId(identifier: 'foo')]
+                #[DataSubjectId(name: 'foo')]
                 #[NormalizedName('_fooId')]
                 public string $fooId,
-                #[PersonalData('fallback', identifier: 'foo')]
+                #[SensitiveData('fallback', subjectIdName: 'foo')]
                 #[NormalizedName('_fooName')]
                 public string $fooName,
-                #[DataSubjectId(identifier: 'bar')]
+                #[DataSubjectId(name: 'bar')]
                 #[NormalizedName('_barId')]
                 public string $barId,
-                #[PersonalData('fallback', identifier: 'bar')]
+                #[SensitiveData('fallback', subjectIdName: 'bar')]
                 #[NormalizedName('_barName')]
                 public string $barName,
             ) {
@@ -426,42 +426,42 @@ final class AttributeMetadataFactoryTest extends TestCase
         self::assertCount(4, $metadata->properties());
 
         $fooIdProperty = $metadata->propertyForField('_fooId');
-        self::assertFalse($fooIdProperty->isPersonalData());
-        self::assertSame(null, $fooIdProperty->personalDataFallback());
+        self::assertFalse($fooIdProperty->isSensitiveData());
+        self::assertSame(null, $fooIdProperty->sensitiveDataFallback());
         self::assertTrue($fooIdProperty->isSubjectId());
-        self::assertSame('foo', $fooIdProperty->subjectIdIdentifier());
+        self::assertSame('foo', $fooIdProperty->subjectIdName());
 
         $fooNameProperty = $metadata->propertyForField('_fooName');
-        self::assertSame(true, $fooNameProperty->isPersonalData());
-        self::assertSame('fallback', $fooNameProperty->personalDataFallback());
-        self::assertSame('foo', $fooNameProperty->personalDataIdentifier());
+        self::assertSame(true, $fooNameProperty->isSensitiveData());
+        self::assertSame('fallback', $fooNameProperty->sensitiveDataFallback());
+        self::assertSame('foo', $fooNameProperty->sensitiveDataSubjectIdName());
 
         $barIdProperty = $metadata->propertyForField('_barId');
-        self::assertFalse($barIdProperty->isPersonalData());
-        self::assertSame(null, $barIdProperty->personalDataFallback());
+        self::assertFalse($barIdProperty->isSensitiveData());
+        self::assertSame(null, $barIdProperty->sensitiveDataFallback());
         self::assertTrue($barIdProperty->isSubjectId());
-        self::assertSame('bar', $barIdProperty->subjectIdIdentifier());
+        self::assertSame('bar', $barIdProperty->subjectIdName());
 
         $barNameProperty = $metadata->propertyForField('_barName');
-        self::assertSame(true, $barNameProperty->isPersonalData());
-        self::assertSame('fallback', $barNameProperty->personalDataFallback());
-        self::assertSame('bar', $barNameProperty->personalDataIdentifier());
+        self::assertSame(true, $barNameProperty->isSensitiveData());
+        self::assertSame('fallback', $barNameProperty->sensitiveDataFallback());
+        self::assertSame('bar', $barNameProperty->sensitiveDataSubjectIdName());
     }
 
     public function testDuplicateSubjectIdIdentifiers(): void
     {
         $event = new class ('fooId', 'fooName', 'barId', 'barName') {
             public function __construct(
-                #[DataSubjectId(identifier: 'foo')]
+                #[DataSubjectId(name: 'foo')]
                 #[NormalizedName('_fooId')]
                 public string $fooId,
-                #[PersonalData('fallback', identifier: 'foo')]
+                #[SensitiveData('fallback', subjectIdName: 'foo')]
                 #[NormalizedName('_fooName')]
                 public string $fooName,
-                #[DataSubjectId(identifier: 'foo')]
+                #[DataSubjectId(name: 'foo')]
                 #[NormalizedName('_barId')]
                 public string $barId,
-                #[PersonalData('fallback', identifier: 'foo')]
+                #[SensitiveData('fallback', subjectIdName: 'foo')]
                 #[NormalizedName('_barName')]
                 public string $barName,
             ) {
@@ -475,10 +475,10 @@ final class AttributeMetadataFactoryTest extends TestCase
         $metadataFactory->metadata($event::class);
     }
 
-    public function testExtendsWithPersonalData(): void
+    public function testExtendsWithSensitiveData(): void
     {
         $metadataFactory = new AttributeMetadataFactory();
-        $metadata = $metadataFactory->metadata(ParentWithPersonalDataDto::class);
+        $metadata = $metadataFactory->metadata(ParentWithSensitiveDataDto::class);
 
         self::assertCount(2, $metadata->properties());
 
@@ -487,7 +487,7 @@ final class AttributeMetadataFactoryTest extends TestCase
         self::assertSame('profileId', $idPropertyMetadata->propertyName());
         self::assertSame('profileId', $idPropertyMetadata->fieldName());
         self::assertTrue($idPropertyMetadata->isSubjectId());
-        self::assertFalse($idPropertyMetadata->isPersonalData());
+        self::assertFalse($idPropertyMetadata->isSensitiveData());
         self::assertInstanceOf(IdNormalizer::class, $idPropertyMetadata->normalizer());
 
         $emailPropertyMetadata = $metadata->propertyForField('email');
@@ -495,14 +495,14 @@ final class AttributeMetadataFactoryTest extends TestCase
         self::assertSame('email', $emailPropertyMetadata->propertyName());
         self::assertSame('email', $emailPropertyMetadata->fieldName());
         self::assertFalse($emailPropertyMetadata->isSubjectId());
-        self::assertTrue($emailPropertyMetadata->isPersonalData());
+        self::assertTrue($emailPropertyMetadata->isSensitiveData());
         self::assertInstanceOf(EmailNormalizer::class, $emailPropertyMetadata->normalizer());
     }
 
-    public function testExtendsWithPersonalDataWithIdentifier(): void
+    public function testExtendsWithSensitiveDataWithName(): void
     {
         $metadataFactory = new AttributeMetadataFactory();
-        $metadata = $metadataFactory->metadata(ParentWithPersonalDataWithIdentifierDto::class);
+        $metadata = $metadataFactory->metadata(ParentWithSensitiveDataWithIdentifierDto::class);
 
         self::assertCount(2, $metadata->properties());
 
@@ -511,7 +511,7 @@ final class AttributeMetadataFactoryTest extends TestCase
         self::assertSame('profileId', $idPropertyMetadata->propertyName());
         self::assertSame('profileId', $idPropertyMetadata->fieldName());
         self::assertTrue($idPropertyMetadata->isSubjectId());
-        self::assertFalse($idPropertyMetadata->isPersonalData());
+        self::assertFalse($idPropertyMetadata->isSensitiveData());
         self::assertInstanceOf(IdNormalizer::class, $idPropertyMetadata->normalizer());
 
         $emailPropertyMetadata = $metadata->propertyForField('email');
@@ -519,9 +519,9 @@ final class AttributeMetadataFactoryTest extends TestCase
         self::assertSame('email', $emailPropertyMetadata->propertyName());
         self::assertSame('email', $emailPropertyMetadata->fieldName());
         self::assertFalse($emailPropertyMetadata->isSubjectId());
-        self::assertTrue($emailPropertyMetadata->isPersonalData());
-        self::assertNull($emailPropertyMetadata->personalDataFallback());
-        self::assertSame('profile', $emailPropertyMetadata->personalDataIdentifier());
+        self::assertTrue($emailPropertyMetadata->isSensitiveData());
+        self::assertNull($emailPropertyMetadata->sensitiveDataFallback());
+        self::assertSame('profile', $emailPropertyMetadata->sensitiveDataSubjectIdName());
         self::assertInstanceOf(EmailNormalizer::class, $emailPropertyMetadata->normalizer());
     }
 


### PR DESCRIPTION
Rename `PersonalData` to `SensitiveData`. This makes clear that the usage can be broader then only personal data from users.

Add missing doc entry for multiple `DataSubjectId`'s.