### PR TITLE
Add support for Stringable as DataSubjectId

### DIFF
--- a/src/Cryptography/PersonalDataPayloadCryptographer.php
+++ b/src/Cryptography/PersonalDataPayloadCryptographer.php
@@ -13,6 +13,7 @@ use Patchlevel\Hydrator\Cryptography\Store\CipherKeyNotExists;
 use Patchlevel\Hydrator\Cryptography\Store\CipherKeyStore;
 use Patchlevel\Hydrator\Metadata\ClassMetadata;
 use Patchlevel\Hydrator\Metadata\PropertyMetadata;
+use Stringable;
 
 use function array_key_exists;
 use function is_int;
@@ -141,6 +142,10 @@ final class PersonalDataPayloadCryptographer implements PayloadCryptographer
 
         if (is_int($subjectId)) {
             $subjectId = (string)$subjectId;
+        }
+
+        if ($subjectId instanceof Stringable) {
+            $subjectId = $subjectId->__toString();
         }
 
         if (!is_string($subjectId)) {

--- a/tests/Unit/Cryptography/PersonalDataPayloadCryptographerTest.php
+++ b/tests/Unit/Cryptography/PersonalDataPayloadCryptographerTest.php
@@ -19,6 +19,8 @@ use Patchlevel\Hydrator\Metadata\ClassMetadata;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Email;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\PersonalDataProfileCreated;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\PersonalDataProfileCreatedFallbackCallback;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\PersonalDataWithStringableSubjectId;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\StringableSubjectId;
 use PHPUnit\Framework\TestCase;
 
 /** @covers \Patchlevel\Hydrator\Cryptography\PersonalDataPayloadCryptographer */
@@ -403,6 +405,41 @@ final class PersonalDataPayloadCryptographerTest extends TestCase
         );
 
         $cryptographer->decrypt($this->metadata(PersonalDataProfileCreated::class), ['email' => 'encrypted']);
+    }
+
+    public function testStringableSubjectId(): void
+    {
+        $cipherKey = new CipherKey(
+            'user-123',
+            'bar',
+            'baz',
+        );
+
+        $cipherKeyStore = $this->createMock(CipherKeyStore::class);
+        $cipherKeyStore->method('get')->willThrowException(new CipherKeyNotExists('user-123'));
+        $cipherKeyStore->expects($this->once())->method('store')->with('user-123', $cipherKey);
+
+        $cipherKeyFactory = $this->createMock(CipherKeyFactory::class);
+        $cipherKeyFactory->expects($this->once())->method('__invoke')->willReturn($cipherKey);
+
+        $cipher = $this->createMock(Cipher::class);
+        $cipher->expects($this->once())->method('encrypt')->with($cipherKey, 'John Doe')
+            ->willReturn('encrypted');
+
+        $cryptographer = new PersonalDataPayloadCryptographer(
+            $cipherKeyStore,
+            $cipherKeyFactory,
+            $cipher,
+        );
+
+        $subjectId = new StringableSubjectId('user-123');
+
+        $result = $cryptographer->encrypt(
+            $this->metadata(PersonalDataWithStringableSubjectId::class),
+            ['subjectId' => $subjectId, 'name' => 'John Doe'],
+        );
+
+        self::assertEquals(['subjectId' => $subjectId, 'name' => 'encrypted'], $result);
     }
 
     public function testCreateWithOpenssl(): void

--- a/tests/Unit/Fixture/PersonalDataWithStringableSubjectId.php
+++ b/tests/Unit/Fixture/PersonalDataWithStringableSubjectId.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
+
+use Patchlevel\Hydrator\Attribute\DataSubjectId;
+use Patchlevel\Hydrator\Attribute\PersonalData;
+
+class PersonalDataWithStringableSubjectId
+{
+    public function __construct(
+        #[DataSubjectId]
+        public StringableSubjectId $subjectId,
+        #[PersonalData]
+        public string $name,
+    ) {
+    }
+}

--- a/tests/Unit/Fixture/StringableSubjectId.php
+++ b/tests/Unit/Fixture/StringableSubjectId.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
+
+use Stringable;
+
+class StringableSubjectId implements Stringable
+{
+    public function __construct(private string $id)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
Adds a failing test to demonstrate desired behaviour.
Adds the necessary feature to the PersonalDataPayloadCryptographer.

Let me know if this should rather target 2.x or needs to be ported there.