### PR TITLE
Introduce `DateIntervalNormalizer`

### DIFF
--- a/src/Guesser/BuiltInGuesser.php
+++ b/src/Guesser/BuiltInGuesser.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator\Guesser;
 
+use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
+use Patchlevel\Hydrator\Normalizer\DateIntervalNormalizer;
 use Patchlevel\Hydrator\Normalizer\DateTimeImmutableNormalizer;
 use Patchlevel\Hydrator\Normalizer\DateTimeNormalizer;
 use Patchlevel\Hydrator\Normalizer\DateTimeZoneNormalizer;
@@ -16,10 +18,10 @@ use Patchlevel\Hydrator\Normalizer\ObjectNormalizer;
 use Symfony\Component\TypeInfo\Type\BackedEnumType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 
-final class BuiltInGuesser implements Guesser
+final readonly class BuiltInGuesser implements Guesser
 {
     public function __construct(
-        private readonly bool $fallbackObjectNormalizer = true,
+        private bool $fallbackObjectNormalizer = true,
     ) {
     }
 
@@ -30,6 +32,7 @@ final class BuiltInGuesser implements Guesser
         }
 
         return match ($type->getClassName()) {
+            DateInterval::class => new DateIntervalNormalizer(),
             DateTimeImmutable::class => new DateTimeImmutableNormalizer(),
             DateTime::class => new DateTimeNormalizer(),
             DateTimeZone::class => new DateTimeZoneNormalizer(),

--- a/src/Normalizer/DateIntervalNormalizer.php
+++ b/src/Normalizer/DateIntervalNormalizer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Normalizer;
+
+use Attribute;
+use DateInterval;
+use Throwable;
+
+use function is_string;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final readonly class DateIntervalNormalizer implements Normalizer
+{
+    private const DEFAULT_FORMAT = 'P%YY%MM%DDT%HH%IM%SS';
+
+    public function __construct(private string $format = self::DEFAULT_FORMAT)
+    {
+    }
+
+    public function normalize(mixed $value): string|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!$value instanceof DateInterval) {
+            throw InvalidArgument::withWrongType('DateInterval|null', $value);
+        }
+
+        return $value->format($this->format);
+    }
+
+    public function denormalize(mixed $value): DateInterval|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value)) {
+            throw InvalidArgument::withWrongType('string|null', $value);
+        }
+
+        try {
+            $interval = new DateInterval($value);
+        } catch (Throwable $e) { // Exception in PHP <= 8.2 or DateMalformedIntervalStringException in 8.3+
+            throw new InvalidArgument('Invalid serialized date interval string', 0, $e);
+        }
+
+        return $interval;
+    }
+}

--- a/tests/Unit/Guesser/BuiltInGuesserTest.php
+++ b/tests/Unit/Guesser/BuiltInGuesserTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator\Tests\Unit\Guesser;
 
+use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use Patchlevel\Hydrator\Guesser\BuiltInGuesser;
+use Patchlevel\Hydrator\Normalizer\DateIntervalNormalizer;
 use Patchlevel\Hydrator\Normalizer\DateTimeImmutableNormalizer;
 use Patchlevel\Hydrator\Normalizer\DateTimeNormalizer;
 use Patchlevel\Hydrator\Normalizer\DateTimeZoneNormalizer;
@@ -59,6 +61,15 @@ final class BuiltInGuesserTest extends TestCase
         self::assertInstanceOf(
             DateTimeZoneNormalizer::class,
             $guesser->guess(Type::object(DateTimeZone::class)),
+        );
+    }
+
+    public function testDateInterval(): void
+    {
+        $guesser = new BuiltInGuesser();
+        self::assertInstanceOf(
+            DateIntervalNormalizer::class,
+            $guesser->guess(Type::object(DateInterval::class)),
         );
     }
 

--- a/tests/Unit/Normalizer/DateIntervalNormalizerTest.php
+++ b/tests/Unit/Normalizer/DateIntervalNormalizerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Normalizer;
+
+use DateInterval;
+use Patchlevel\Hydrator\Normalizer\DateIntervalNormalizer;
+use Patchlevel\Hydrator\Normalizer\InvalidArgument;
+use PHPUnit\Framework\TestCase;
+
+final class DateIntervalNormalizerTest extends TestCase
+{
+    public function testNormalizeWithNull(): void
+    {
+        $normalizer = new DateIntervalNormalizer();
+        self::assertNull($normalizer->normalize(null));
+    }
+
+    public function testDenormalizeWithNull(): void
+    {
+        $normalizer = new DateIntervalNormalizer();
+        self::assertNull($normalizer->denormalize(null));
+    }
+
+    public function testNormalizeWithInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionCode(0);
+
+        $normalizer = new DateIntervalNormalizer();
+        $normalizer->normalize(123);
+    }
+
+    public function testDenormalizeWithInvalidArgument(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionCode(0);
+
+        $normalizer = new DateIntervalNormalizer();
+        $normalizer->denormalize(123);
+    }
+
+    public function testNormalizeWithValue(): void
+    {
+        $normalizer = new DateIntervalNormalizer();
+        self::assertSame('P02Y02M25DT06H07M08S', $normalizer->normalize(new DateInterval('P2Y2M3W4DT6H7M8S')));
+    }
+
+    public function testNormalizeWithChangeFormat(): void
+    {
+        $normalizer = new DateIntervalNormalizer(format: 'P%YY%MM');
+        self::assertSame('P02Y02M', $normalizer->normalize(new DateInterval('P2Y2M3W4DT6H7M8S')));
+    }
+
+    public function testDenormalizeWithValue(): void
+    {
+        $normalizer = new DateIntervalNormalizer();
+        $denormalized = $normalizer->denormalize('P00Y00M35DT00H00M00S');
+        self::assertNotNull($denormalized);
+
+        $this->assertEqualInterval(
+            new DateInterval('P5W'),
+            $denormalized,
+        );
+    }
+
+    public function testDenormalizeWithChangeFormat(): void
+    {
+        $normalizer = new DateIntervalNormalizer(format: 'P%YY');
+        $denormalized = $normalizer->denormalize('P5Y');
+        self::assertNotNull($denormalized);
+
+        $this->assertEqualInterval(
+            new DateInterval('P5Y'),
+            $denormalized,
+        );
+    }
+
+    public function testDateIntervalErrorsAreCaughtAndReThrown(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage('Invalid serialized date interval string');
+        $this->expectExceptionCode(0);
+
+        (new DateIntervalNormalizer())->denormalize('Kermit');
+    }
+
+    private function assertEqualInterval(DateInterval $a, DateInterval $b): void
+    {
+        self::assertSame($a->y, $b->y);
+        self::assertSame($a->m, $b->m);
+        self::assertSame($a->d, $b->d);
+        self::assertSame($a->h, $b->h);
+        self::assertSame($a->i, $b->i);
+        self::assertSame($a->s, $b->s);
+        self::assertSame($a->invert, $b->invert);
+        self::assertSame($a->f, $b->f);
+        self::assertSame($a->days, $b->days);
+    }
+}


### PR DESCRIPTION
Adds a normalizer for `DateInterval` instances.

Before this patch, serializing properties with this type would yield an empty array. The added normalizer converts intervals to a string with the greatest possible precision (Seconds) using the standard ISO interval string format.