### PR TITLE
Introduce a `Mapped Guesser`

### DIFF
--- a/src/Guesser/MappedGuesser.php
+++ b/src/Guesser/MappedGuesser.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Guesser;
+
+use Patchlevel\Hydrator\Normalizer\Normalizer;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+
+use function array_key_exists;
+
+final readonly class MappedGuesser implements Guesser
+{
+    /** @param array<class-string, class-string<Normalizer>> $map */
+    public function __construct(private array $map)
+    {
+    }
+
+    /**
+     * @param ObjectType<T> $type
+     *
+     * @template T
+     */
+    public function guess(ObjectType $type): Normalizer|null
+    {
+        $className = $type->getClassName();
+        if (! array_key_exists($className, $this->map)) {
+            return null;
+        }
+
+        $normalizerType = $this->map[$className];
+
+        return new $normalizerType();
+    }
+}

--- a/tests/Unit/Guesser/MappedGuesserTest.php
+++ b/tests/Unit/Guesser/MappedGuesserTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Guesser;
+
+use Patchlevel\Hydrator\Guesser\MappedGuesser;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\Email;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\EmailNormalizer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+
+final class MappedGuesserTest extends TestCase
+{
+    public function testTheNormalizerIsNullWhenTheTypeHasNotBeenMapped(): void
+    {
+        $guesser = new MappedGuesser([]);
+
+        self::assertNull($guesser->guess(new ObjectType(Email::class)));
+    }
+
+    public function testTheNormalizerIsOfTheExpectedType(): void
+    {
+        $guesser = new MappedGuesser([
+            Email::class => EmailNormalizer::class,
+        ]);
+
+        $normalizer = $guesser->guess(new ObjectType(Email::class));
+
+        self::assertInstanceOf(EmailNormalizer::class, $normalizer);
+    }
+}


### PR DESCRIPTION
There's currently no easy way to avoid adding attributes in order to configure which normalizers to use for which types.

This `MappedGuesser` is a trivial Guesser implementation allowing users to specify a map of `Type::class => Normalizer::class` as an alternative to adding attributes to targets