### PR TITLE
rename union object normalizer into object map normalizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,19 +308,29 @@ final class AnotherDto
 > [!WARNING]
 > Circular references are not supported and will result in an exception.
 
-#### Union Object
+#### ObjectMap
 
-If you have a union type from multiple classes, then you can use the `UnionObjectNormalizer` normalizer
+You can also use the `ObjectMapNormalizer` if you have either inheritance or a union type.
 
 ```php
-use Patchlevel\Hydrator\Normalizer\UnionObjectNormalizer;
+use Patchlevel\Hydrator\Normalizer\ObjectMapNormalizer;
 
-#[UnionObjectNormalizer([
-  ContentBlock::class => 'content',
-  CodeBlock::class => 'code'
+// inheritance
+#[ObjectMapNormalizer([
+    ContentBlock::class => 'content',
+    CodeBlock::class => 'code'
 ])]
 interface Block
 {
+}
+
+// union type
+class ContentBlock implements Block {
+    #[ObjectMapNormalizer([
+       ContentA::class => 'content',
+       ContentB::class => 'code'
+    ])]
+    public ContentA|ContentB $content;
 }
 ```
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -85,6 +85,12 @@ parameters:
 			path: src/Normalizer/EnumNormalizer.php
 
 		-
+			message: '#^Parameter \#2 \$data of method Patchlevel\\Hydrator\\Hydrator\:\:hydrate\(\) expects array\<string, mixed\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Normalizer/ObjectMapNormalizer.php
+
+		-
 			message: '#^Parameter \#2 \$data of method Patchlevel\\Hydrator\\Hydrator\:\:hydrate\(\) expects array\<string, mixed\>, array\<mixed, mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
@@ -101,12 +107,6 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: src/Normalizer/ReflectionTypeUtil.php
-
-		-
-			message: '#^Parameter \#2 \$data of method Patchlevel\\Hydrator\\Hydrator\:\:hydrate\(\) expects array\<string, mixed\>, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Normalizer/UnionObjectNormalizer.php
 
 		-
 			message: '#^Method Patchlevel\\Hydrator\\Tests\\Unit\\Fixture\\DtoWithHooks\:\:postHydrate\(\) is unused\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,7 @@ parameters:
 	paths:
 		- src
 		- tests
+	reportUnmatchedIgnoredErrors: false
 
 services:
 	-

--- a/src/Normalizer/ObjectMapNormalizer.php
+++ b/src/Normalizer/ObjectMapNormalizer.php
@@ -17,7 +17,7 @@ use function is_string;
 use function sprintf;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
-final class UnionObjectNormalizer implements Normalizer, HydratorAwareNormalizer
+final class ObjectMapNormalizer implements Normalizer, HydratorAwareNormalizer
 {
     private Hydrator|null $hydrator = null;
 

--- a/tests/Unit/Normalizer/ObjectMapNormalizerTest.php
+++ b/tests/Unit/Normalizer/ObjectMapNormalizerTest.php
@@ -7,7 +7,7 @@ namespace Patchlevel\Hydrator\Tests\Unit\Normalizer;
 use Patchlevel\Hydrator\Hydrator;
 use Patchlevel\Hydrator\Normalizer\InvalidArgument;
 use Patchlevel\Hydrator\Normalizer\MissingHydrator;
-use Patchlevel\Hydrator\Normalizer\UnionObjectNormalizer;
+use Patchlevel\Hydrator\Normalizer\ObjectMapNormalizer;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Email;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ProfileId;
@@ -17,14 +17,14 @@ use PHPUnit\Framework\TestCase;
 use function serialize;
 use function unserialize;
 
-#[CoversClass(UnionObjectNormalizer::class)]
-final class UnionObjectNormalizerTest extends TestCase
+#[CoversClass(ObjectMapNormalizer::class)]
+final class ObjectMapNormalizerTest extends TestCase
 {
     public function testNormalizeMissingHydrator(): void
     {
         $this->expectException(MissingHydrator::class);
 
-        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer = new ObjectMapNormalizer([ProfileCreated::class => 'created']);
         $this->assertEquals(null, $normalizer->normalize(null));
     }
 
@@ -32,7 +32,7 @@ final class UnionObjectNormalizerTest extends TestCase
     {
         $this->expectException(MissingHydrator::class);
 
-        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer = new ObjectMapNormalizer([ProfileCreated::class => 'created']);
         $this->assertEquals(null, $normalizer->denormalize(null));
     }
 
@@ -40,7 +40,7 @@ final class UnionObjectNormalizerTest extends TestCase
     {
         $hydrator = $this->createStub(Hydrator::class);
 
-        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer = new ObjectMapNormalizer([ProfileCreated::class => 'created']);
         $normalizer->setHydrator($hydrator);
 
         $this->assertEquals(null, $normalizer->normalize(null));
@@ -50,7 +50,7 @@ final class UnionObjectNormalizerTest extends TestCase
     {
         $hydrator = $this->createStub(Hydrator::class);
 
-        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer = new ObjectMapNormalizer([ProfileCreated::class => 'created']);
         $normalizer->setHydrator($hydrator);
 
         $this->assertEquals(null, $normalizer->denormalize(null));
@@ -63,7 +63,7 @@ final class UnionObjectNormalizerTest extends TestCase
 
         $hydrator = $this->createStub(Hydrator::class);
 
-        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer = new ObjectMapNormalizer([ProfileCreated::class => 'created']);
         $normalizer->setHydrator($hydrator);
         $normalizer->normalize('foo');
     }
@@ -75,7 +75,7 @@ final class UnionObjectNormalizerTest extends TestCase
 
         $hydrator = $this->createStub(Hydrator::class);
 
-        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer = new ObjectMapNormalizer([ProfileCreated::class => 'created']);
         $normalizer->setHydrator($hydrator);
         $normalizer->denormalize('foo');
     }
@@ -95,7 +95,7 @@ final class UnionObjectNormalizerTest extends TestCase
             ->with($event)
             ->willReturn(['profileId' => '1', 'email' => 'info@patchlevel.de']);
 
-        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer = new ObjectMapNormalizer([ProfileCreated::class => 'created']);
         $normalizer->setHydrator($hydrator);
 
         self::assertEquals(
@@ -119,7 +119,7 @@ final class UnionObjectNormalizerTest extends TestCase
             ->with(ProfileCreated::class, ['profileId' => '1', 'email' => 'info@patchlevel.de'])
             ->willReturn($expected);
 
-        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer = new ObjectMapNormalizer([ProfileCreated::class => 'created']);
         $normalizer->setHydrator($hydrator);
 
         $this->assertEquals(
@@ -132,13 +132,13 @@ final class UnionObjectNormalizerTest extends TestCase
     {
         $hydrator = $this->createStub(Hydrator::class);
 
-        $normalizer = new UnionObjectNormalizer([ProfileCreated::class => 'created']);
+        $normalizer = new ObjectMapNormalizer([ProfileCreated::class => 'created']);
         $normalizer->setHydrator($hydrator);
 
         $serialized = serialize($normalizer);
         $normalizer2 = unserialize($serialized);
 
-        self::assertInstanceOf(UnionObjectNormalizer::class, $normalizer2);
-        self::assertEquals(new UnionObjectNormalizer([ProfileCreated::class => 'created']), $normalizer2);
+        self::assertInstanceOf(ObjectMapNormalizer::class, $normalizer2);
+        self::assertEquals(new ObjectMapNormalizer([ProfileCreated::class => 'created']), $normalizer2);
     }
 }


### PR DESCRIPTION
You can use the `ObjectMapNormalizer` if you have either inheritance or a union type.

```php
use Patchlevel\Hydrator\Normalizer\ObjectMapNormalizer;

// inheritance
#[ObjectMapNormalizer([
    ContentBlock::class => 'content',
    CodeBlock::class => 'code'
])]
interface Block
{
}

// union type
class ContentBlock implements Block 
{
    #[ObjectMapNormalizer([
       ContentA::class => 'content',
       ContentB::class => 'code'
    ])]
    public ContentA|ContentB $content;
}
```