### PR TITLE
add cryptography store cache

### DIFF
--- a/src/Extension/Cryptography/Store/Psr16CacheStoreDecorator.php
+++ b/src/Extension/Cryptography/Store/Psr16CacheStoreDecorator.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Extension\Cryptography\Store;
+
+use DateInterval;
+use Patchlevel\Hydrator\Extension\Cryptography\Cipher\CipherKey;
+use Psr\SimpleCache\CacheInterface;
+
+final readonly class Psr16CacheStoreDecorator implements CipherKeyStore
+{
+    public function __construct(
+        private CipherKeyStore $cipherKeyStore,
+        private CacheInterface $cache,
+        private DateInterval|int|null $ttl = null,
+    ) {
+    }
+
+    public function currentKeyFor(string $subjectId): CipherKey
+    {
+        $key = 'subjectId:' . $subjectId;
+        $entry = $this->cache->get($key);
+
+        if ($entry instanceof CipherKey) {
+            return $entry;
+        }
+
+        $entry = $this->cipherKeyStore->currentKeyFor($subjectId);
+
+        $this->cache->set($key, $entry, $this->ttl);
+
+        return $entry;
+    }
+
+    public function get(string $id): CipherKey
+    {
+        $key = 'id:' . $id;
+        $entry = $this->cache->get($key);
+
+        if ($entry instanceof CipherKey) {
+            return $entry;
+        }
+
+        $entry = $this->cipherKeyStore->get($id);
+
+        $this->cache->set($key, $entry, $this->ttl);
+
+        return $entry;
+    }
+
+    public function store(CipherKey $key): void
+    {
+        $this->cipherKeyStore->store($key);
+
+        $this->cache->set('id:' . $key->id, $key, $this->ttl);
+        $this->cache->set('subjectId:' . $key->subjectId, $key, $this->ttl);
+    }
+
+    public function remove(string $id): void
+    {
+        $this->cipherKeyStore->remove($id);
+
+        $this->cache->delete('id:' . $id);
+    }
+
+    public function removeWithSubjectId(string $subjectId): void
+    {
+        $this->cipherKeyStore->removeWithSubjectId($subjectId);
+
+        $this->cache->delete('subjectId:' . $subjectId);
+    }
+}

--- a/src/Extension/Cryptography/Store/Psr6CacheStoreDecorator.php
+++ b/src/Extension/Cryptography/Store/Psr6CacheStoreDecorator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Extension\Cryptography\Store;
+
+use DateInterval;
+use Patchlevel\Hydrator\Extension\Cryptography\Cipher\CipherKey;
+use Psr\Cache\CacheItemPoolInterface;
+
+final readonly class Psr6CacheStoreDecorator implements CipherKeyStore
+{
+    public function __construct(
+        private CipherKeyStore $cipherKeyStore,
+        private CacheItemPoolInterface $cache,
+        private DateInterval|int|null $expiresAfter = null,
+    ) {
+    }
+
+    public function currentKeyFor(string $subjectId): CipherKey
+    {
+        $key = 'subjectId:' . $subjectId;
+        $item = $this->cache->getItem($key);
+        $entry = $item->get();
+
+        if ($item->isHit() && $entry instanceof CipherKey) {
+            return $entry;
+        }
+
+        $entry = $this->cipherKeyStore->currentKeyFor($subjectId);
+
+        $item->set($entry);
+        $item->expiresAfter($this->expiresAfter);
+        $this->cache->save($item);
+
+        return $entry;
+    }
+
+    public function get(string $id): CipherKey
+    {
+        $key = 'id:' . $id;
+        $item = $this->cache->getItem($key);
+        $entry = $item->get();
+
+        if ($item->isHit() && $entry instanceof CipherKey) {
+            return $entry;
+        }
+
+        $entry = $this->cipherKeyStore->get($id);
+
+        $item->set($entry);
+        $item->expiresAfter($this->expiresAfter);
+        $this->cache->save($item);
+
+        return $entry;
+    }
+
+    public function store(CipherKey $key): void
+    {
+        $this->cipherKeyStore->store($key);
+    }
+
+    public function remove(string $id): void
+    {
+        $this->cipherKeyStore->remove($id);
+
+        $this->cache->deleteItem('id:' . $id);
+    }
+
+    public function removeWithSubjectId(string $subjectId): void
+    {
+        $this->cipherKeyStore->removeWithSubjectId($subjectId);
+
+        $this->cache->deleteItem('subjectId:' . $subjectId);
+    }
+}

--- a/tests/Unit/Extension/Cryptography/Store/Psr16CacheStoreDecoratorTest.php
+++ b/tests/Unit/Extension/Cryptography/Store/Psr16CacheStoreDecoratorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Extension\Cryptography\Store;
+
+use DateTimeImmutable;
+use Patchlevel\Hydrator\Extension\Cryptography\Cipher\CipherKey;
+use Patchlevel\Hydrator\Extension\Cryptography\Store\CipherKeyStore;
+use Patchlevel\Hydrator\Extension\Cryptography\Store\Psr16CacheStoreDecorator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+#[CoversClass(Psr16CacheStoreDecorator::class)]
+final class Psr16CacheStoreDecoratorTest extends TestCase
+{
+    public function testCurrentKeyForWithCacheHit(): void
+    {
+        $key = $this->createKey();
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->with('subjectId:subject-1')->willReturn($key);
+        $cache->expects(self::never())->method('set');
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::never())->method('currentKeyFor');
+
+        $store = new Psr16CacheStoreDecorator($innerStore, $cache);
+
+        self::assertSame($key, $store->currentKeyFor('subject-1'));
+    }
+
+    public function testCurrentKeyForWithCacheMiss(): void
+    {
+        $key = $this->createKey();
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->with('subjectId:subject-1')->willReturn(null);
+        $cache->expects(self::once())->method('set')->with('subjectId:subject-1', $key, 42);
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('currentKeyFor')->with('subject-1')->willReturn($key);
+
+        $store = new Psr16CacheStoreDecorator($innerStore, $cache, 42);
+
+        self::assertSame($key, $store->currentKeyFor('subject-1'));
+    }
+
+    public function testGetWithCacheMiss(): void
+    {
+        $key = $this->createKey();
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->with('id:key-1')->willReturn(false);
+        $cache->expects(self::once())->method('set')->with('id:key-1', $key, null);
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('get')->with('key-1')->willReturn($key);
+
+        $store = new Psr16CacheStoreDecorator($innerStore, $cache);
+
+        self::assertSame($key, $store->get('key-1'));
+    }
+
+    public function testStoreWritesInnerStoreAndBothCacheEntries(): void
+    {
+        $key = $this->createKey();
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::exactly(2))->method('set')->willReturnMap([
+            ['id:key-1', $key, 17, true],
+            ['subjectId:subject-1', $key, 17, true],
+        ]);
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('store')->with($key);
+
+        $store = new Psr16CacheStoreDecorator($innerStore, $cache, 17);
+        $store->store($key);
+    }
+
+    public function testRemoveDeletesIdCacheEntry(): void
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('delete')->with('id:key-1');
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('remove')->with('key-1');
+
+        $store = new Psr16CacheStoreDecorator($innerStore, $cache);
+        $store->remove('key-1');
+    }
+
+    public function testRemoveWithSubjectIdDeletesSubjectCacheEntry(): void
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('delete')->with('subjectId:subject-1');
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('removeWithSubjectId')->with('subject-1');
+
+        $store = new Psr16CacheStoreDecorator($innerStore, $cache);
+        $store->removeWithSubjectId('subject-1');
+    }
+
+    private function createKey(): CipherKey
+    {
+        return new CipherKey(
+            'key-1',
+            'subject-1',
+            'secret',
+            'aes-256-gcm',
+            new DateTimeImmutable(),
+        );
+    }
+}

--- a/tests/Unit/Extension/Cryptography/Store/Psr6CacheStoreDecoratorTest.php
+++ b/tests/Unit/Extension/Cryptography/Store/Psr6CacheStoreDecoratorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Extension\Cryptography\Store;
+
+use DateTimeImmutable;
+use Patchlevel\Hydrator\Extension\Cryptography\Cipher\CipherKey;
+use Patchlevel\Hydrator\Extension\Cryptography\Store\CipherKeyStore;
+use Patchlevel\Hydrator\Extension\Cryptography\Store\Psr6CacheStoreDecorator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+#[CoversClass(Psr6CacheStoreDecorator::class)]
+final class Psr6CacheStoreDecoratorTest extends TestCase
+{
+    public function testCurrentKeyForWithCacheHit(): void
+    {
+        $key = $this->createKey();
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item->expects(self::once())->method('get')->willReturn($key);
+        $item->expects(self::once())->method('isHit')->willReturn(true);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->expects(self::once())->method('getItem')->with('subjectId:subject-1')->willReturn($item);
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::never())->method('currentKeyFor');
+
+        $store = new Psr6CacheStoreDecorator($innerStore, $cache);
+
+        self::assertSame($key, $store->currentKeyFor('subject-1'));
+    }
+
+    public function testCurrentKeyForWithCacheMiss(): void
+    {
+        $key = $this->createKey();
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item->expects(self::once())->method('get')->willReturn(null);
+        $item->expects(self::once())->method('isHit')->willReturn(false);
+        $item->expects(self::once())->method('set')->with($key)->willReturnSelf();
+        $item->expects(self::once())->method('expiresAfter')->with(42)->willReturnSelf();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->expects(self::once())->method('getItem')->with('subjectId:subject-1')->willReturn($item);
+        $cache->expects(self::once())->method('save')->with($item);
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('currentKeyFor')->with('subject-1')->willReturn($key);
+
+        $store = new Psr6CacheStoreDecorator($innerStore, $cache, 42);
+
+        self::assertSame($key, $store->currentKeyFor('subject-1'));
+    }
+
+    public function testGetWithCacheMiss(): void
+    {
+        $key = $this->createKey();
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item->expects(self::once())->method('get')->willReturn(null);
+        $item->expects(self::once())->method('isHit')->willReturn(false);
+        $item->expects(self::once())->method('set')->with($key)->willReturnSelf();
+        $item->expects(self::once())->method('expiresAfter')->with(null)->willReturnSelf();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->expects(self::once())->method('getItem')->with('id:key-1')->willReturn($item);
+        $cache->expects(self::once())->method('save')->with($item);
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('get')->with('key-1')->willReturn($key);
+
+        $store = new Psr6CacheStoreDecorator($innerStore, $cache);
+
+        self::assertSame($key, $store->get('key-1'));
+    }
+
+    public function testStoreDelegatesToInnerStore(): void
+    {
+        $key = $this->createKey();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->expects(self::never())->method('getItem');
+        $cache->expects(self::never())->method('save');
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('store')->with($key);
+
+        $store = new Psr6CacheStoreDecorator($innerStore, $cache);
+        $store->store($key);
+    }
+
+    public function testRemoveDeletesIdCacheEntry(): void
+    {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->expects(self::once())->method('deleteItem')->with('id:key-1');
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('remove')->with('key-1');
+
+        $store = new Psr6CacheStoreDecorator($innerStore, $cache);
+        $store->remove('key-1');
+    }
+
+    public function testRemoveWithSubjectIdDeletesSubjectCacheEntry(): void
+    {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->expects(self::once())->method('deleteItem')->with('subjectId:subject-1');
+
+        $innerStore = $this->createMock(CipherKeyStore::class);
+        $innerStore->expects(self::once())->method('removeWithSubjectId')->with('subject-1');
+
+        $store = new Psr6CacheStoreDecorator($innerStore, $cache);
+        $store->removeWithSubjectId('subject-1');
+    }
+
+    private function createKey(): CipherKey
+    {
+        return new CipherKey(
+            'key-1',
+            'subject-1',
+            'secret',
+            'aes-256-gcm',
+            new DateTimeImmutable(),
+        );
+    }
+}


### PR DESCRIPTION
A cache prevents the system from searching for the key in the database for every encryption and decryption operation. Even caching the key for just a few seconds can significantly improve performance.