### PR TITLE
legacy cryptography attribute metadata mapping

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,6 +67,12 @@ parameters:
 			path: src/Extension/Cryptography/Cipher/OpensslCipherKeyFactory.php
 
 		-
+			message: '#^Cannot access property \$nameToField on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Extension/Cryptography/LegacyCryptographyMetadataEnricher.php
+
+		-
 			message: '#^Method Patchlevel\\Hydrator\\Guesser\\BuiltInGuesser\:\:guess\(\) has parameter \$type with generic class Symfony\\Component\\TypeInfo\\Type\\ObjectType but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1

--- a/src/Extension/Cryptography/CryptographyExtension.php
+++ b/src/Extension/Cryptography/CryptographyExtension.php
@@ -14,6 +14,7 @@ final class CryptographyExtension implements Extension
     public function __construct(
         private readonly Cryptographer $cryptography,
         private readonly PayloadCryptographer|null $legacyCryptographer = null,
+        private readonly bool $legacyMetadataMapping = false,
     ) {
     }
 
@@ -21,6 +22,10 @@ final class CryptographyExtension implements Extension
     {
         $builder->addMetadataEnricher(new CryptographyMetadataEnricher(), 64);
         $builder->addMiddleware(new CryptographyMiddleware($this->cryptography), 64);
+
+        if ($this->legacyMetadataMapping) {
+            $builder->addMetadataEnricher(new LegacyCryptographyMetadataEnricher(), 63);
+        }
 
         if ($this->legacyCryptographer === null) {
             return;

--- a/src/Extension/Cryptography/LegacyCryptographyMetadataEnricher.php
+++ b/src/Extension/Cryptography/LegacyCryptographyMetadataEnricher.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Extension\Cryptography;
+
+use Patchlevel\Hydrator\Attribute\DataSubjectId;
+use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Metadata\ClassMetadata;
+use Patchlevel\Hydrator\Metadata\MetadataEnricher;
+use ReflectionProperty;
+
+use function array_key_exists;
+use function in_array;
+
+final class LegacyCryptographyMetadataEnricher implements MetadataEnricher
+{
+    private const SUBJECT_ID = 'legacy';
+
+    public function enrich(ClassMetadata $classMetadata): void
+    {
+        /** @var array<string, string> $subjectIdMapping */
+        $subjectIdMapping = isset($classMetadata->extras[SubjectIdFieldMapping::class])
+            ? $classMetadata->extras[SubjectIdFieldMapping::class]->nameToField
+            : [];
+
+        foreach ($classMetadata->properties as $property) {
+            $attributeReflectionList = $property->reflection->getAttributes(DataSubjectId::class);
+
+            if ($attributeReflectionList) {
+                if (array_key_exists(self::SUBJECT_ID, $subjectIdMapping)) {
+                    throw new DuplicateSubjectIdIdentifier(
+                        $classMetadata->className,
+                        $classMetadata->propertyForField($subjectIdMapping[self::SUBJECT_ID])->propertyName,
+                        $property->propertyName,
+                        self::SUBJECT_ID,
+                    );
+                }
+
+                $subjectIdMapping[self::SUBJECT_ID] = $property->fieldName;
+            }
+
+            $sensitiveDataInfo = $this->sensitiveDataInfo($property->reflection);
+
+            if (!$sensitiveDataInfo) {
+                continue;
+            }
+
+            if (in_array($property->fieldName, $subjectIdMapping, true)) {
+                throw new SubjectIdAndSensitiveDataConflict($classMetadata->className, $property->propertyName);
+            }
+
+            if (isset($property->extras[SensitiveDataInfo::class])) {
+                throw new PersonalDataAndSensitiveDataOnSameProperty($classMetadata->className, $property->propertyName);
+            }
+
+            $property->extras[SensitiveDataInfo::class] = $sensitiveDataInfo;
+        }
+
+        if ($subjectIdMapping === []) {
+            return;
+        }
+
+        $classMetadata->extras[SubjectIdFieldMapping::class] = new SubjectIdFieldMapping($subjectIdMapping);
+    }
+
+    private function sensitiveDataInfo(ReflectionProperty $reflectionProperty): SensitiveDataInfo|null
+    {
+        $attributeReflectionList = $reflectionProperty->getAttributes(PersonalData::class);
+
+        if ($attributeReflectionList === []) {
+            return null;
+        }
+
+        $attribute = $attributeReflectionList[0]->newInstance();
+
+        return new SensitiveDataInfo(
+            self::SUBJECT_ID,
+            $attribute->fallbackCallable !== null ? ($attribute->fallbackCallable)(...) : $attribute->fallback,
+        );
+    }
+}

--- a/src/Extension/Cryptography/PersonalDataAndSensitiveDataOnSameProperty.php
+++ b/src/Extension/Cryptography/PersonalDataAndSensitiveDataOnSameProperty.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Extension\Cryptography;
+
+use Patchlevel\Hydrator\Metadata\MetadataException;
+use RuntimeException;
+
+use function sprintf;
+
+/** @experimental */
+final class PersonalDataAndSensitiveDataOnSameProperty extends RuntimeException implements MetadataException
+{
+    /** @param class-string $class */
+    public function __construct(string $class, string $property)
+    {
+        parent::__construct(
+            sprintf(
+                'Personal data and sensitive data cannot be used on the same property %s::%s',
+                $class,
+                $property,
+            ),
+        );
+    }
+}

--- a/src/StackHydratorBuilder.php
+++ b/src/StackHydratorBuilder.php
@@ -81,15 +81,11 @@ final class StackHydratorBuilder
 
     public function build(): StackHydrator
     {
-        krsort($this->guessers);
-        krsort($this->metadataEnrichers);
-        krsort($this->middlewares);
-
         $metadataFactory = new EnrichingMetadataFactory(
             new AttributeMetadataFactory(
-                guesser: new ChainGuesser(array_merge(...$this->guessers)),
+                guesser: new ChainGuesser($this->guessers()),
             ),
-            array_merge(...$this->metadataEnrichers),
+            $this->metadataEnrichers(),
         );
 
         if ($this->cache instanceof CacheItemPoolInterface) {
@@ -102,8 +98,37 @@ final class StackHydratorBuilder
 
         return new StackHydrator(
             $metadataFactory,
-            array_merge(...$this->middlewares),
+            $this->middlewares(),
             $this->defaultLazy,
         );
+    }
+
+    public function defaultLazy(): bool
+    {
+        return $this->defaultLazy;
+    }
+
+    /** @return list<Middleware> */
+    public function middlewares(): array
+    {
+        krsort($this->middlewares);
+
+        return array_merge(...$this->middlewares);
+    }
+
+    /** @return list<Guesser> */
+    public function guessers(): array
+    {
+        krsort($this->guessers);
+
+        return array_merge(...$this->guessers);
+    }
+
+    /** @return list<MetadataEnricher> */
+    public function metadataEnrichers(): array
+    {
+        krsort($this->metadataEnrichers);
+
+        return array_merge(...$this->metadataEnrichers);
     }
 }

--- a/tests/Unit/Extension/Cryptography/CryptographyExtensionTest.php
+++ b/tests/Unit/Extension/Cryptography/CryptographyExtensionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Extension\Cryptography;
+
+use Patchlevel\Hydrator\Cryptography\PayloadCryptographer;
+use Patchlevel\Hydrator\Extension\Cryptography\Cryptographer;
+use Patchlevel\Hydrator\Extension\Cryptography\CryptographyExtension;
+use Patchlevel\Hydrator\Extension\Cryptography\CryptographyMetadataEnricher;
+use Patchlevel\Hydrator\Extension\Cryptography\CryptographyMiddleware;
+use Patchlevel\Hydrator\Extension\Cryptography\LegacyCryptographyDecryptMiddleware;
+use Patchlevel\Hydrator\Extension\Cryptography\LegacyCryptographyMetadataEnricher;
+use Patchlevel\Hydrator\StackHydratorBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CryptographyExtension::class)]
+final class CryptographyExtensionTest extends TestCase
+{
+    public function testConfigureWithoutLegacyOptions(): void
+    {
+        $builder = new StackHydratorBuilder();
+        $cryptographer = $this->createMock(Cryptographer::class);
+
+        $extension = new CryptographyExtension($cryptographer);
+        $extension->configure($builder);
+
+        $middlewares = $builder->middlewares();
+        self::assertCount(1, $middlewares);
+        self::assertInstanceOf(CryptographyMiddleware::class, $middlewares[0]);
+
+        $metadataEnrichers = $builder->metadataEnrichers();
+        self::assertCount(1, $metadataEnrichers);
+        self::assertInstanceOf(CryptographyMetadataEnricher::class, $metadataEnrichers[0]);
+    }
+
+    public function testConfigureWithLegacyMetadataMapping(): void
+    {
+        $builder = new StackHydratorBuilder();
+        $cryptographer = $this->createMock(Cryptographer::class);
+
+        $extension = new CryptographyExtension($cryptographer, legacyMetadataMapping: true);
+        $extension->configure($builder);
+
+        $metadataEnrichers = $builder->metadataEnrichers();
+        self::assertCount(2, $metadataEnrichers);
+        self::assertInstanceOf(CryptographyMetadataEnricher::class, $metadataEnrichers[0]);
+        self::assertInstanceOf(LegacyCryptographyMetadataEnricher::class, $metadataEnrichers[1]);
+    }
+
+    public function testConfigureWithLegacyCryptographerAndMetadataMapping(): void
+    {
+        $builder = new StackHydratorBuilder();
+        $cryptographer = $this->createMock(Cryptographer::class);
+        $legacyCryptographer = $this->createMock(PayloadCryptographer::class);
+
+        $extension = new CryptographyExtension($cryptographer, $legacyCryptographer, true);
+        $extension->configure($builder);
+
+        $middlewares = $builder->middlewares();
+        self::assertCount(2, $middlewares);
+        self::assertInstanceOf(LegacyCryptographyDecryptMiddleware::class, $middlewares[0]);
+        self::assertInstanceOf(CryptographyMiddleware::class, $middlewares[1]);
+
+        $metadataEnrichers = $builder->metadataEnrichers();
+        self::assertCount(2, $metadataEnrichers);
+        self::assertInstanceOf(CryptographyMetadataEnricher::class, $metadataEnrichers[0]);
+        self::assertInstanceOf(LegacyCryptographyMetadataEnricher::class, $metadataEnrichers[1]);
+    }
+}

--- a/tests/Unit/Extension/Cryptography/LegacyCryptographyMetadataEnricherTest.php
+++ b/tests/Unit/Extension/Cryptography/LegacyCryptographyMetadataEnricherTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Extension\Cryptography;
+
+use Patchlevel\Hydrator\Attribute\DataSubjectId as LegacyDataSubjectId;
+use Patchlevel\Hydrator\Attribute\NormalizedName;
+use Patchlevel\Hydrator\Attribute\PersonalData;
+use Patchlevel\Hydrator\Extension\Cryptography\Attribute\DataSubjectId;
+use Patchlevel\Hydrator\Extension\Cryptography\Attribute\SensitiveData;
+use Patchlevel\Hydrator\Extension\Cryptography\CryptographyMetadataEnricher;
+use Patchlevel\Hydrator\Extension\Cryptography\DuplicateSubjectIdIdentifier;
+use Patchlevel\Hydrator\Extension\Cryptography\LegacyCryptographyMetadataEnricher;
+use Patchlevel\Hydrator\Extension\Cryptography\PersonalDataAndSensitiveDataOnSameProperty;
+use Patchlevel\Hydrator\Extension\Cryptography\SensitiveDataInfo;
+use Patchlevel\Hydrator\Extension\Cryptography\SubjectIdAndSensitiveDataConflict;
+use Patchlevel\Hydrator\Extension\Cryptography\SubjectIdFieldMapping;
+use Patchlevel\Hydrator\Metadata\AttributeMetadataFactory;
+use Patchlevel\Hydrator\Metadata\ClassMetadata;
+use Patchlevel\Hydrator\Metadata\MetadataEnricher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LegacyCryptographyMetadataEnricher::class)]
+final class LegacyCryptographyMetadataEnricherTest extends TestCase
+{
+    public function testSensitiveData(): void
+    {
+        $event = new class ('id', 'name') {
+            public function __construct(
+                #[LegacyDataSubjectId]
+                #[NormalizedName('_id')]
+                public string $id,
+                #[PersonalData('fallback')]
+                #[NormalizedName('_name')]
+                public string $name,
+            ) {
+            }
+        };
+
+        $metadata = $this->metadata($event::class, new LegacyCryptographyMetadataEnricher());
+
+        self::assertArrayHasKey(SubjectIdFieldMapping::class, $metadata->extras);
+        $subjectIdFieldMapping = $metadata->extras[SubjectIdFieldMapping::class];
+        self::assertInstanceOf(SubjectIdFieldMapping::class, $subjectIdFieldMapping);
+        self::assertSame(['legacy' => '_id'], $subjectIdFieldMapping->nameToField);
+
+        $property = $metadata->propertyForField('_name');
+        self::assertArrayHasKey(SensitiveDataInfo::class, $property->extras);
+        self::assertEquals(new SensitiveDataInfo('legacy', 'fallback'), $property->extras[SensitiveDataInfo::class]);
+    }
+
+    public function testSubjectIdAndSensitiveDataConflict(): void
+    {
+        $event = new class ('legacy', 'id', 'name') {
+            public function __construct(
+                #[LegacyDataSubjectId]
+                public string $legacyId,
+                #[DataSubjectId]
+                #[PersonalData]
+                public string $id,
+                public string $name,
+            ) {
+            }
+        };
+
+        $this->expectException(SubjectIdAndSensitiveDataConflict::class);
+
+        $this->metadata(
+            $event::class,
+            new CryptographyMetadataEnricher(),
+            new LegacyCryptographyMetadataEnricher(),
+        );
+    }
+
+    public function testMultipleDataSubjectIdWithSameIdentifier(): void
+    {
+        $event = new class ('legacyId', 'id', 'name') {
+            public function __construct(
+                #[LegacyDataSubjectId]
+                public string $legacyId,
+                #[DataSubjectId(name: 'legacy')]
+                public string $id,
+                public string $name,
+            ) {
+            }
+        };
+
+        $this->expectException(DuplicateSubjectIdIdentifier::class);
+
+        $this->metadata(
+            $event::class,
+            new CryptographyMetadataEnricher(),
+            new LegacyCryptographyMetadataEnricher(),
+        );
+    }
+
+    public function testPersonalDataAndSensitiveDataOnSameProperty(): void
+    {
+        $event = new class ('id', 'name') {
+            public function __construct(
+                #[LegacyDataSubjectId]
+                public string $id,
+                #[SensitiveData]
+                #[PersonalData]
+                public string $name,
+            ) {
+            }
+        };
+
+        $this->expectException(PersonalDataAndSensitiveDataOnSameProperty::class);
+
+        $this->metadata(
+            $event::class,
+            new CryptographyMetadataEnricher(),
+            new LegacyCryptographyMetadataEnricher(),
+        );
+    }
+
+    public function testNoLegacyAttributes(): void
+    {
+        $event = new class {
+        };
+
+        $metadata = $this->metadata($event::class, new LegacyCryptographyMetadataEnricher());
+
+        self::assertArrayNotHasKey(SubjectIdFieldMapping::class, $metadata->extras);
+    }
+
+    /** @param class-string $class */
+    private function metadata(string $class, MetadataEnricher ...$enricherList): ClassMetadata
+    {
+        $metadata = (new AttributeMetadataFactory())->metadata($class);
+
+        foreach ($enricherList as $enricher) {
+            $enricher->enrich($metadata);
+        }
+
+        return $metadata;
+    }
+}

--- a/tests/Unit/StackHydratorBuilderTest.php
+++ b/tests/Unit/StackHydratorBuilderTest.php
@@ -39,6 +39,7 @@ final class StackHydratorBuilderTest extends TestCase
         $middlewares = $reflection->getValue($hydrator);
 
         self::assertSame([$middleware2, $middleware1], $middlewares);
+        self::assertSame([$middleware2, $middleware1], $builder->middlewares());
     }
 
     public function testAddMetadataEnricherWithPriority(): void
@@ -61,6 +62,7 @@ final class StackHydratorBuilderTest extends TestCase
         $enrichers = $reflection->getValue($enrichingMetadataFactory);
 
         self::assertSame([$enricher2, $enricher1], $enrichers);
+        self::assertSame([$enricher2, $enricher1], $builder->metadataEnrichers());
     }
 
     public function testAddGuesserWithPriority(): void
@@ -93,6 +95,7 @@ final class StackHydratorBuilderTest extends TestCase
         $guessers = $reflection->getValue($guesser);
 
         self::assertSame([$guesser2, $guesser1], $guessers);
+        self::assertSame([$guesser2, $guesser1], $builder->guessers());
     }
 
     public function testEnableDefaultLazy(): void
@@ -104,6 +107,7 @@ final class StackHydratorBuilderTest extends TestCase
 
         $reflection = new ReflectionProperty(StackHydrator::class, 'defaultLazy');
         self::assertTrue($reflection->getValue($hydrator));
+        self::assertTrue($builder->defaultLazy());
     }
 
     public function testUseExtension(): void


### PR DESCRIPTION
Allow the use of the old cryptography attribute with the new stack hydrator and cryptography extension for an even easier switch from metadata hydrator to stack hydrator.