### PR TITLE
`HydratorException` should be `Throwable`

### DIFF
--- a/src/HydratorException.php
+++ b/src/HydratorException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Patchlevel\Hydrator;
 
-interface HydratorException
+use Throwable;
+
+interface HydratorException extends Throwable
 {
 }


### PR DESCRIPTION
This is a technical BC break, but it's extremely unlikely that users will have implemented this interface on a non-throwable.

This fixes code for static analysers such as:

```php
try {
   return $hydrator->extract($object);
} catch(HydratorException $e) {
   throw new MyException('Foo', 0, $e);
}
```