### PR TITLE
Failing test case for covariant templates

### DIFF
--- a/tests/Unit/Fixture/CovariantTemplate.php
+++ b/tests/Unit/Fixture/CovariantTemplate.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\Hydrator\Tests\Unit\Fixture;
+
+use Patchlevel\Hydrator\Normalizer\ArrayNormalizer;
+use Patchlevel\Hydrator\Normalizer\ObjectNormalizer;
+
+/** @template-covariant T of object */
+final readonly class CovariantTemplate
+{
+    /** @param list<T> $objects */
+    public function __construct(
+        #[ArrayNormalizer(new ObjectNormalizer())]
+        public array $objects,
+    ) {
+    }
+}

--- a/tests/Unit/MetadataHydratorTest.php
+++ b/tests/Unit/MetadataHydratorTest.php
@@ -23,6 +23,7 @@ use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle1Dto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle2Dto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Circle3Dto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\ContextAwareDto;
+use Patchlevel\Hydrator\Tests\Unit\Fixture\CovariantTemplate;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\DefaultDto;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\DtoWithHooks;
 use Patchlevel\Hydrator\Tests\Unit\Fixture\Email;
@@ -665,5 +666,19 @@ final class MetadataHydratorTest extends TestCase
         ));
 
         self::assertSame(4, $guesser->count);
+    }
+
+    public function testTypesWithCovariantTemplatesCanBeSerialisedAndHydrated(): void
+    {
+        $object = new CovariantTemplate([
+            (object)['foo' => 1],
+            (object)['foo' => 2],
+        ]);
+
+        $serialized = $this->hydrator->extract($object);
+        $hydrated = $this->hydrator->hydrate(CovariantTemplate::class, $serialized);
+
+        self::assertNotSame($object, $hydrated);
+        self::assertEquals($object, $hydrated);
     }
 }


### PR DESCRIPTION
It is currently not possible to serialize types that are documented with `@template-covariant`