### PR TITLE
Fix ArrayNormalizer mutating the source array

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -259,6 +259,18 @@ parameters:
 			path: tests/Unit/MetadataHydratorTest.php
 
 		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with array\{1, 2, 3\} and array\{1, 2, 3\} will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Normalizer/ArrayNormalizerTest.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with array\{101, 102, 103\} and array\{101, 102, 103\} will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: tests/Unit/Normalizer/ArrayNormalizerTest.php
+
+		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 2

--- a/src/Normalizer/ArrayNormalizer.php
+++ b/src/Normalizer/ArrayNormalizer.php
@@ -35,17 +35,19 @@ final readonly class ArrayNormalizer implements NormalizerWithContext, TypeAware
             throw InvalidArgument::withWrongType('array|null', $value);
         }
 
+        $result = [];
+
         if ($this->normalizer instanceof NormalizerWithContext) {
-            foreach ($value as &$item) {
-                $item = $this->normalizer->normalize($item, $context);
+            foreach ($value as $key => $item) {
+                $result[$key] = $this->normalizer->normalize($item, $context);
             }
         } else {
-            foreach ($value as &$item) {
-                $item = $this->normalizer->normalize($item);
+            foreach ($value as $key => $item) {
+                $result[$key] = $this->normalizer->normalize($item);
             }
         }
 
-        return $value;
+        return $result;
     }
 
     /**
@@ -63,17 +65,19 @@ final readonly class ArrayNormalizer implements NormalizerWithContext, TypeAware
             throw InvalidArgument::withWrongType('array|null', $value);
         }
 
+        $result = [];
+
         if ($this->normalizer instanceof NormalizerWithContext) {
-            foreach ($value as &$item) {
-                $item = $this->normalizer->denormalize($item, $context);
+            foreach ($value as $key => $item) {
+                $result[$key] = $this->normalizer->denormalize($item, $context);
             }
         } else {
-            foreach ($value as &$item) {
-                $item = $this->normalizer->denormalize($item);
+            foreach ($value as $key => $item) {
+                $result[$key] = $this->normalizer->denormalize($item);
             }
         }
 
-        return $value;
+        return $result;
     }
 
     public function setHydrator(Hydrator $hydrator): void

--- a/tests/Unit/Normalizer/ArrayNormalizerTest.php
+++ b/tests/Unit/Normalizer/ArrayNormalizerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\Hydrator\Tests\Unit\Normalizer;
 
 use Attribute;
+use InvalidArgumentException;
 use Patchlevel\Hydrator\Hydrator;
 use Patchlevel\Hydrator\Normalizer\ArrayNormalizer;
 use Patchlevel\Hydrator\Normalizer\HydratorAwareNormalizer;
@@ -12,6 +13,8 @@ use Patchlevel\Hydrator\Normalizer\InvalidArgument;
 use Patchlevel\Hydrator\Normalizer\Normalizer;
 use Patchlevel\Hydrator\Normalizer\NormalizerWithContext;
 use PHPUnit\Framework\TestCase;
+
+use function is_int;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class ArrayNormalizerTest extends TestCase
@@ -150,6 +153,79 @@ final class ArrayNormalizerTest extends TestCase
         $normalizer->denormalize(['a', 'b'], $context);
 
         $this->assertSame([$context, $context], $innerNormalizer->contexts);
+    }
+
+    public function testNormalizeDoesNotMutateSourceArrayWithReferencedElement(): void
+    {
+        $innerNormalizer = new class implements Normalizer {
+            public function normalize(mixed $value): int
+            {
+                if (!is_int($value)) {
+                    throw new InvalidArgumentException();
+                }
+
+                return $value + 100;
+            }
+
+            public function denormalize(mixed $value): int
+            {
+                if (!is_int($value)) {
+                    throw new InvalidArgumentException();
+                }
+
+                return $value - 100;
+            }
+        };
+
+        $source = [1, 2, 3];
+
+        // A leftover reference from a previous `foreach ($source as &$row)` without
+        // unset() turns the last element into a PHP reference. Iterating the source
+        // by reference inside the normalizer must not write back into it.
+        // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedForeach
+        foreach ($source as &$row) {
+        }
+
+        $normalizer = new ArrayNormalizer($innerNormalizer);
+        $result = $normalizer->normalize($source);
+
+        self::assertSame([101, 102, 103], $result);
+        self::assertSame([1, 2, 3], $source);
+    }
+
+    public function testDenormalizeDoesNotMutateSourceArrayWithReferencedElement(): void
+    {
+        $innerNormalizer = new class implements Normalizer {
+            public function normalize(mixed $value): int
+            {
+                if (!is_int($value)) {
+                    throw new InvalidArgumentException();
+                }
+
+                return $value + 100;
+            }
+
+            public function denormalize(mixed $value): int
+            {
+                if (!is_int($value)) {
+                    throw new InvalidArgumentException();
+                }
+
+                return $value - 100;
+            }
+        };
+
+        $source = [101, 102, 103];
+
+        // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedForeach
+        foreach ($source as &$row) {
+        }
+
+        $normalizer = new ArrayNormalizer($innerNormalizer);
+        $result = $normalizer->denormalize($source);
+
+        self::assertSame([1, 2, 3], $result);
+        self::assertSame([101, 102, 103], $source);
     }
 
     public function testPassHydrator(): void


### PR DESCRIPTION
normalize()/denormalize() iterated the input with `foreach ($value as &$item)` and wrote the result back in place. When the source array contained a reference element (e.g. a leftover `&$row` from an earlier foreach without unset), copy-on-write didn't kick in and the original array got mutated during extraction. Build a fresh result array instead of writing through references.      